### PR TITLE
Made sure newlines are removed from the system paths

### DIFF
--- a/dmenu_extended.py
+++ b/dmenu_extended.py
@@ -222,7 +222,7 @@ class dmenu(object):
         Array containing system paths
         """
         path = str(subprocess.check_output("echo $PATH", shell=True))
-        path = path.replace('\\n','').replace('b\'','').replace('\'','')
+        path = path.replace('\n','').replace('\\n','').replace('b\'','').replace('\'','')
         path = list(set(path.split(':'))) # Split and remove duplicates
         return path
 


### PR DESCRIPTION
When trying out the `application_finder` branch, I got:

```
OSError: [Errno 2] No such file or directory: '/usr/games\n'
```

So I've fixed the `system_path` method in `master`, which removes the bug. I wasn't sure if `.replace('\\n','')` was also needed, so I left it in.

I'll suspend the pull request for the `application_finder` branch until I've had a good look at the whole thing, to make sure there aren't any other small bugs.
