### PR TITLE
Application Finder Branch

### DIFF
--- a/dmenu_extended.py
+++ b/dmenu_extended.py
@@ -5,6 +5,8 @@ import os
 import subprocess
 import signal
 import json
+import codecs
+import locale
 
 # Python 3 urllib import with Python 2 fallback
 try:
@@ -553,7 +555,8 @@ class dmenu(object):
             for filename in os.listdir(app_path):
                 pathname = os.path.join(app_path,filename)
                 if os.path.isfile(pathname):
-                    with open(pathname,'r') as f:
+                    # Open the application file using the system's preferred encoding (probably utf-8)
+                    with codecs.open(pathname,'r',encoding=locale.getpreferredencoding()) as f:
                         name = None
                         command = None
                         terminal = None


### PR DESCRIPTION
Hello again!

I've tried out this branch; it all seems great. I've made two small changes, for you to consider:
- I've made it so that the application directories are determined in accordance with the [XDG specification](http://standards.freedesktop.org/basedir-spec/basedir-spec-latest.html). In particular this means that local applications (i.e. those in `~/.local/share/applications`) are now included.
- I've fixed a small bug: when using Python 2.7, applications whose name contained non-ascii characters triggered `UnicodeDecodeError`s. This didn't happen in Python 3. What I've done is use `codecs.open()` with `encoding=locale.getpreferredencoding()` instead of just `open()`. This is basically what Python 3 was doing. (By the way, I've noticed that when using Python 3, entries containing non-ascii characters get written to the cache, while when using Python 2.7 they don't, because they trigger the `UnicodeEncodeError` [here](https://github.com/markjones112358/dmenu-extended/blob/3e3fb21ec5efbe8754f652ba09aa1d7422c5774c/dmenu_extended.py#L439). Is there a reason for this?)

What are your thoughts on these changes?
