### PR TITLE
Fix systemd install script; fix for bash aliases with quotes

### DIFF
--- a/dmenu_extended.py
+++ b/dmenu_extended.py
@@ -895,8 +895,7 @@ class dmenu(object):
                 if line[:6].lower() == 'alias ':
                     # I'm splitting this on the '=' char but there may be another
                     # one in the alias command so join the remainder of the split
-                    # again with '=' chars
-                    #parts = line[6:].replace('\n','').replace("\'",'\\\'').replace('"','\\"').split('=')           
+                    # again with '=' chars          
                     parts = line[6:].replace('\n', '').split('=')
                     # I'm sure there is a way to do this all in a regex
                     # We want to remove any outer quotes on the alias but preserve interior quotes

--- a/dmenu_extended.py
+++ b/dmenu_extended.py
@@ -622,6 +622,21 @@ class dmenu(object):
                         break
             for index, part in enumerate(out):
                 out[index] = part.replace('"', '')
+                
+        quote_count = "".join(out).count("'")
+        if quote_count > 0 and quote_count % 2 == 0:
+            # Bring split parts that were enclosed by single quotes back together
+            restart = 1
+            while restart:
+                restart = 0
+                for index, part in enumerate(out):
+                    if part.count("'") % 2 != 0 and index + 1 <= len(out) - 1:
+                        out[index] = out[index] + ' ' + out[index+1]
+                        del(out[index+1])
+                        restart = 1
+                        break
+            for index, part in enumerate(out):
+                out[index] = part.replace("'", '')                
         return out
 
 
@@ -881,7 +896,13 @@ class dmenu(object):
                     # I'm splitting this on the '=' char but there may be another
                     # one in the alias command so join the remainder of the split
                     # again with '=' chars
-                    parts = line[6:].replace('\n','').replace('\'','').replace('"','').split('=')
+                    #parts = line[6:].replace('\n','').replace("\'",'\\\'').replace('"','\\"').split('=')           
+                    parts = line[6:].replace('\n', '').split('=')
+                    # I'm sure there is a way to do this all in a regex
+                    # We want to remove any outer quotes on the alias but preserve interior quotes
+                    if (parts[1][0] == '"' and parts[-1][-1] == '"') or (parts[1][0] == "'" and parts[-1][-1] == "'"):
+                        parts[1] = parts[1][1:]
+                        parts[-1] = parts[-1][:-1]									                     
                     out.append([parts[0], "=".join(parts[1:])])
         return out
 

--- a/setup.py
+++ b/setup.py
@@ -19,8 +19,5 @@ setup(name='dmenu_extended',
       # packages=['dmenu_extended', 'dmenu_extended/config', 'dmenu_extended/plugins'],
       scripts=['dmenu_extended_run', 'dmenu_extended_cache_build'],
       data_files=[('share/dmenu-extended/', ['systemd-install.sh']),
-                  ('share/dmenu-extended/systemd',
-                      ['systemd/update-dmenu-extended-db.system.service',
-                       'systemd/update-dmenu-extended-db.user.service',
-                       'systemd/update-dmenu-extended-db.timer'])]
+                  ('share/dmenu-extended/systemd', ['systemd/update-dmenu-extended-db.timer'])]
       )

--- a/systemd-install.sh
+++ b/systemd-install.sh
@@ -15,12 +15,20 @@ do
 	esac
 done
 
+DECB_NONDEFAULT=false;
+
 if [ "$PER_USER_INSTALL" == "YES" ] ; then
 	SCRIPT_PATH=$HOME/.local/share/systemd/user
-	SERVICE_UNIT_NAME=update-dmenu-extended-db.user.service
+	DECB_DEFAULT=~/.local/bin/dmenu_extended_cache_build
+	if [ ! -f $DECB_DEFAULT ]; then		
+		DECB_NONDEFAULT=true
+	fi
 else
 	SCRIPT_PATH=/usr/lib/systemd/user
-	SERVICE_UNIT_NAME=update-dmenu-extended-db.system.service
+	DECB_DEFAULT=/usr/bin/dmenu_extended_cache_build
+	if [ ! -f DECB_DEFAULT ]; then
+		DECB_NONDEFAULT=true
+	fi
 fi
 
 if [ "$UNINSTALL" == "YES" ]; then
@@ -35,5 +43,35 @@ if [ ! -d "$SCRIPT_PATH" ]; then
 fi
 
 echo "Installing systemd service in $SCRIPT_PATH..."
-cp -v systemd/$SERVICE_UNIT_NAME $SCRIPT_PATH/update-dmenu-extended-db.service
+
+if [ $DECB_NONDEFAULT ]; then
+	echo "dmenu_extended_cache_build not found at the default location."
+	echo "Please enter the full path to dmenu_extended_cache_build:"
+	read DECB_PATH
+else
+	DECB_PATH = $DECB_DEFAULT
+fi;
+
+# If per-user install, we need systemd to call dmenu_extended_cache build with /bin/sh -c
+if [ "$PER_USER_INSTALL" == "YES" ]; then
+	SYSTEMD_EXEC='/bin/sh -c "$DECB_PATH"'
+else
+	SYSTEMD_EXEC=$DECB_PATH
+fi
+
+# Clear old file (if exists) then (re)write
+if [ -f $SCRIPT_PATH/update-dmenu-extended-db.service ]; then
+	rm $SCRIPT_PATH/update-dmenu-extended-db.service
+fi
+
+cat <<EOT >> $SCRIPT_PATH/update-dmenu-extended-db.service
+[Unit]
+Description=Updates the database file used by dmenu_extended_run
+
+[Service]
+Type=oneshot
+User=%i
+ExecStart=$SYSTEMD_EXEC
+EOT
+echo "$SCRIPT_PATH/update-dmenu-extended-db.service created."
 cp -v systemd/update-dmenu-extended-db.timer $SCRIPT_PATH

--- a/systemd/update-dmenu-extended-db.system.service
+++ b/systemd/update-dmenu-extended-db.system.service
@@ -1,7 +1,0 @@
-[Unit]
-Description=Updates the database file used by dmenu_extended_run
-
-[Service]
-Type=oneshot
-User=%i
-ExecStart=/usr/bin/dmenu_extended_cache_build

--- a/systemd/update-dmenu-extended-db.user.service
+++ b/systemd/update-dmenu-extended-db.user.service
@@ -1,7 +1,0 @@
-[Unit]
-Description=Updates the database file used by dmenu_extended_run
-
-[Service]
-Type=oneshot
-User=%i
-ExecStart=/bin/sh -c "~/.local/bin/dmenu_extended_cache_build"


### PR DESCRIPTION
Changed the systemd-install.sh script in order to fix the problem in Issue #53. Previously the installer script would copy the two unit files from ./systemd/ to the appropriate systemd services directory. However, the systemd units referenced the dmenu_extended_cache_build script at /usr/bin/ or ~/.local/bin/, which is indeed where they are installed by the python distutils installer. However, if the user manually installed dmenu-extended elsewhere, the files would be missing and the systemd service wouldn't work.
My fix is to check if the cache_build script is installed at the default location. If yes, then the unit files are created like before (although they are now written by the script instead of being copied over). If no, then the user is prompted to fill in the path to the cache_build script, then the unit files are written with the appropriate location.

I also had problems getting bash aliases with internal quotes to work properly, e.g.
`alias excel="wine '/home/stephen/.wine/drive_c/Program Files/Microsoft Office/Office12/EXCEL.EXE'"`
It seems that _all_ quotes were being stripped from aliases before they were saved to the JSON file. It's possible there's a good reason for this - if so please explain. But things seem to work if only the outer quotes (i.e. after the equals sign and at the end of the line) are removed.
 