### PR TITLE
Option to open file in terminal editor

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,7 @@ Functions of the items are as follows.
 * `"filebrowser"` application to handle opening folders
 * `"webbrowser"` application to handle opening urls (web browser)
 * `"terminal"` terminal emulator application
+* `"terminal_editor"` application used to edit files directly in the terminal
 * `"indicator_submenu"` symbol to indicate a submenu item in the cache
 * `"indicator_edit"` symbol to indicate an item will launch an editor in the cache
 * `"indicator_alias"` symbol to indicate an aliased command in the cache
@@ -195,7 +196,8 @@ Dmenu-extended understands the following modifier characters when entering a spe
 1. **+** (plus) - Manually add an entry to the cache
 2. **-** (minus) - Remove a manually added entry from the cache
 3. **:** (colon) - Open with
-4. **;** (semi-colon) - Execute in terminal
+4. **@** (at) - Open in default terminal editor
+5. **;** (semi-colon) - Execute in terminal
 
 These modifiers are entered into the menu; examples follow.
 
@@ -227,6 +229,10 @@ There are a few different ways to use the colon operator, summarised by example 
 * `/home/me/Documents/writing.txt:` - Open this file using... Returns a list of applications to launch the given file
 * `/home/me/Documents/writing.txt:gedit` - Open this file with gedit.
 * `gedit:/home/me/Documents/writing.txt` - Open this file with gedit.
+
+### **@** (at) - Open in terminal editor
+
+Default editor is set to `vim`, but it can be changed in the preferences (`"terminal_editor"`). The terminal window is closed as soon as the application is exited.
 
 ### **;** (semi-colon) - Execute in terminal
 Dmenu-extended doesn't know when the application you enter needs to be executed in a terminal window. To tell dmenu-extended to launch the following in a terminal, append a semi-colon to the end. Once the terminal program has exited the terminal will close.

--- a/README.md
+++ b/README.md
@@ -232,7 +232,10 @@ There are a few different ways to use the colon operator, summarised by example 
 
 ### **@** (at) - Open in terminal editor
 
-Default editor is set to `vim`, but it can be changed in the preferences (`"terminal_editor"`). The terminal window is closed as soon as the application is exited.
+Suffix to open the chosen file inside the preferred editor in a terminal window. Default editor is set to `vim`, but it can be changed in the preferences (`"terminal_editor"`). The terminal window is closed as soon as the application is exited.
+For instance:
+
+* `/home/me/Documents/writing.txt@`
 
 ### **;** (semi-colon) - Execute in terminal
 Dmenu-extended doesn't know when the application you enter needs to be executed in a terminal window. To tell dmenu-extended to launch the following in a terminal, append a semi-colon to the end. Once the terminal program has exited the terminal will close.

--- a/dmenu_extended/main.py
+++ b/dmenu_extended/main.py
@@ -148,6 +148,7 @@ default_prefs = {
     "filebrowser": "xdg-open",          # Program to handle opening paths
     "webbrowser": "xdg-open",           # Program to hangle opening urls
     "terminal": "xterm",                # Terminal
+    "terminal_editor": "vim",           # Terminal editor
     "indicator_submenu": "->",          # Symbol to indicate a submenu item
     "indicator_edit": "*",              # Symbol to indicate an item will launch an editor
     "indicator_alias": "",              # Symbol to indecate an aliased command
@@ -585,6 +586,27 @@ class dmenu(object):
             os.system('sh -e ' + sh_command_file)
         else:
             os.system(self.prefs['terminal'] + ' -e ' + sh_command_file)
+
+
+    def open_in_terminal_editor(self, path):
+        if not os.path.exists(path):
+            if d.debug:
+                print("Open in the default terminal editor...")
+                print(str(path) + ": path doesn't exist")
+            return
+
+        cmd = "%s -e '%s %s'" % (
+            d.prefs['terminal'],
+            d.prefs['terminal_editor'],
+            path.replace(' ', '\\ ')
+        )
+
+        if d.debug:
+            print("Open in the default terminal editor...")
+            print("Terminal will be held open upon command finishing")
+            print("Command is: " + str(cmd))
+
+        return d.execute(cmd, False)
 
 
     def open_file(self, path):
@@ -1531,7 +1553,9 @@ def handle_command(d, out):
         out = os.path.expanduser(out)
         if d.debug:
             print("Tilda found, expanding to " + str(out))
-    if out[-1] == ';':
+    if out[-1] == '@':
+        d.open_in_terminal_editor(out[:-1])
+    elif out[-1] == ';':
         terminal_hold = False
         out = out[:-1]
         if out[-1] == ';':


### PR DESCRIPTION
Add suffix @, that causes the file to be opened in the default terminal
editor (set to vim), using the default terminal.

I made these modification because I find it difficult to open files in a terminal in some other way. The alternative is the one you described [here](https://github.com/MarkHedleyJones/dmenu-extended/issues/87#issuecomment-524596240), but while it works for the file manager (where the app is called directly), somehow it doesn't work for in dmenu_extended for me (`xdg_open` insists in opening a terminal with `less`). It may be caused by some issues with concatenation of commands `xdg_open -> terminal emulator -> terminal app -> file`.

No idea, but this is a direct way to solve the problem and it doesn't need a system-wide change (like changing the default application for a filetype).

There is also the non small benefit that the method `open_in_terminal_editor(path)` can be called directly by plugins.