### PR TITLE
Add abbreviate_homedir option

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,7 @@ Functions of the items are as follows.
 * `"include_applications"` add items found under /usr/share/applications
 * `"alias_applications"` alias applications with their intended names
 * `"path_aliasFile"` path to a file containing aliases (e.g. ~/.bash_aliases)
+* `"abbreviate_homedir"` abbreviate $HOME as `~` for files & folders
 * `"frequently_used"` the number of your most frequently used commands to show at the top of the menu
 * `"alias_display_format"` how to format aliased commands (e.g. `"{name} ({command})"`)
 * `"path_shellCommand"` path to use for creating terminal helper script (e.g. "~/.dmenuEextended_shellCommand.sh")

--- a/dmenu_extended/main.py
+++ b/dmenu_extended/main.py
@@ -115,10 +115,11 @@ default_prefs = {
     "include_items": [],                # Extra items to display - manually added
     "exclude_items": [],                # Items to hide - manually hidden
     "include_binaries": False,
-    "filter_binaries": False,            # Only include binaries that have an associated .desktop file
+    "filter_binaries": False,           # Only include binaries that have an associated .desktop file
     "include_applications": True,       # Add items from /usr/share/applications
     "alias_applications": True,         # Alias applications with their common names
     "path_aliasFile": "",               # Pointer to an aliases file (if any)
+    "abbreviate_homedir": False,        # Use ~ in place of /home/username
     "frequently_used": 0,               # Number of most frequently used commands to show in the menu
     "alias_display_format": "{name}",
     "path_shellCommand": "~/.dmenuEextended_shellCommand.sh",
@@ -1129,6 +1130,11 @@ class dmenu(object):
                         foldernames.append(os.path.join(root,name) + '/')
 
         foldernames = list(filter(lambda x: x not in ignore_folders, foldernames))
+
+        if 'abbreviate_homedir' in self.prefs:
+          homedir = os.path.expanduser("~")
+          filenames = list(map(lambda x: x.replace(homedir, "~"), filenames))
+          foldernames = list(map(lambda x: x.replace(homedir, "~"), foldernames))
 
         include_items = []
 

--- a/dmenu_extended/main.py
+++ b/dmenu_extended/main.py
@@ -1131,7 +1131,7 @@ class dmenu(object):
 
         foldernames = list(filter(lambda x: x not in ignore_folders, foldernames))
 
-        if 'abbreviate_homedir' in self.prefs:
+        if 'abbreviate_homedir' in self.prefs and self.prefs['abbreviate_homedir']:
           homedir = os.path.expanduser("~")
           filenames = list(map(lambda x: x.replace(homedir, "~"), filenames))
           foldernames = list(map(lambda x: x.replace(homedir, "~"), foldernames))


### PR DESCRIPTION
closes #105 

Adds a new parameter `abbreviate_homedir` that enables replacing `/home/username` with `~` in files & folders.