### PR TITLE
Add system tests

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,8 @@
+*.egg
+*.egg-info
+*.pytest_cache
+*.whl
+*__pycache__*
+build
+dist
+docs

--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,9 @@
+*.egg-info*
 *.pyc
-cache.txt
-settings.txt
-build/*
-*.swp
-*.sublime-workspace
 *.sublime-project
+*.sublime-workspace
+*.swp
+build/*
+cache.txt
+dist
+settings.txt

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "dmenu_extended"
-version = "1.1.0"
+version = "1.1.1"
 authors = [
   { name="Mark Hedley Jones", email="markhedleyjones@gmail.com" },
 ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+build
+mock
+pytest

--- a/test.sh
+++ b/test.sh
@@ -1,4 +1,48 @@
-#!/usr/bin/env sh
+#!/usr/bin/env bash
 
-cd src/dmenu_extended
-python3 -m pytest ../../tests
+script_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && pwd -P)
+
+usage() {
+  cat <<EOF
+Usage: $(
+    basename "${BASH_SOURCE[0]}"
+  ) [-h] [-f]
+
+Run dmenu-extended tests
+
+Available options:
+
+-h, --help      Print this help and exit
+-f, --full      Run full test-suite (requires docker)
+EOF
+  exit
+}
+
+parse_params() {
+  full=0
+  while :; do
+    case "${1-}" in
+    -h | --help) usage ;;
+    -f | --full) full=1 ;;
+    -?*)
+      echo "Unknown option: $1"
+      exit 1
+      ;;
+    *) break ;;
+    esac
+    shift
+  done
+  args=("$@")
+  return 0
+}
+
+parse_params "$@"
+
+if [ "${full}" -eq 1 ]; then
+  docker build -f ${script_dir}/tests/Dockerfile -t dmenu-extended-test:latest .
+  docker run -it --rm dmenu-extended-test:latest bash -c "cd /home/user/dmenu-extended/src/dmenu_extended && python3 -m pytest ../../tests"
+  docker run -it --rm dmenu-extended-test:latest /home/user/dmenu-extended/tests/system_tests.sh
+else
+  cd ${script_dir}/src/dmenu_extended
+  python3 -m pytest ../../tests
+fi

--- a/tests/Dockerfile
+++ b/tests/Dockerfile
@@ -1,0 +1,23 @@
+FROM python:3-slim
+
+# Setup the user account
+RUN addgroup --gid 1000 user \
+  && adduser --disabled-password --gecos '' --gid 1000 --uid 1000 user
+USER user
+WORKDIR /home/user
+ENV PATH=/home/user/.local/bin:$PATH
+
+# Copy the package into the image
+COPY --chown=user requirements.txt /home/user/dmenu-extended/requirements.txt
+
+# Upgrade pip and install required packages for build
+RUN python -m pip install --upgrade pip \
+  && pip install --upgrade --no-cache-dir -r dmenu-extended/requirements.txt
+
+# Copy the package into the image
+COPY --chown=user . /home/user/dmenu-extended
+
+# Install dmenu-extended into the image
+RUN cd /home/user/dmenu-extended \
+  && python3 -m build --wheel \
+  && pip3 install dist/dmenu_extended-*-py3-none-any.whl --upgrade

--- a/tests/system_tests.sh
+++ b/tests/system_tests.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+
+failed_tests=()
+current_test=""
+
+start_test() {
+  current_test="$1"
+  echo ""
+  echo "Running test: $1 ..."
+  if [ -f /tmp/output ]; then
+    rm /tmp/output
+  fi
+}
+
+pass() {
+  echo " ✓ ${current_test} passed"
+}
+
+fail() {
+  echo " ✗ ${current_test} failed"
+  failed_tests+=("${current_test}")
+  if [ -f /tmp/output ]; then
+    cat /tmp/output
+  fi
+}
+
+## TEST DEFINITIONS ##
+
+start_test "dmenu_extended_cache_build"
+if dmenu_extended_cache_build >/tmp/output; then pass; else fail; fi
+
+start_test "Check dmenu-extended folder in ~/.cache"
+if [ -d ~/.cache/dmenu-extended ]; then pass; else fail; fi
+
+target="/home/user/dmenu-extended/"
+start_test "Check the folder: dmenu-extended was added to the cache"
+if cat ~/.cache/dmenu-extended/dmenuExtended_folders.txt | grep ${target} >/dev/null; then pass; else fail; fi
+
+target="/home/user/dmenu-extended/src/dmenu_extended/main.py"
+start_test "Check the file: main.py was added to the cache"
+if cat ~/.cache/dmenu-extended/dmenuExtended_files.txt | grep ${target} >/dev/null; then pass; else fail; fi
+
+## TEST SUMMARY ##
+
+echo ""
+if [ ${#failed_tests[@]} -eq 0 ]; then
+  echo "All tests passed"
+  exit 0
+else
+  echo "Failed tests:"
+  for test in "${failed_tests[@]}"; do
+    echo "  ${test}"
+  done
+  exit 1
+fi


### PR DESCRIPTION
Closes #118 

This pull-request allows the user to simply run `test.sh --full` which will build a docker container, run the unit tests, then run the system tests.
These should be enabled in CI (will create another issue for that)