### PR TITLE
Feature/interactive aliases

### DIFF
--- a/README.md
+++ b/README.md
@@ -290,3 +290,4 @@ For those looking to improve the code, the code uses [Black](https://github.com/
 * [**nanobecquerel**](https://github.com/nanobecquerel) for improving systemd integration
 * [**fat-fighter**](https://github.com/fat-fighter) for bug fixes and solving GitHub issues
 * [**vestingz**](https://github.com/vestingz) for Incron and pacman integration.
+* [**ZappaBoy**](https://github.com/ZappaBoy) for improving alias/shell integration

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "dmenu_extended"
-version = "1.1.4"
+version = "1.2.0"
 authors = [
   { name="Mark Hedley Jones", email="markhedleyjones@gmail.com" },
 ]

--- a/src/dmenu_extended/main.py
+++ b/src/dmenu_extended/main.py
@@ -203,6 +203,7 @@ default_prefs = {
     "indicator_edit": "*",  # Symbol to indicate an item will launch an editor
     "indicator_alias": "",  # Symbol to indicate an aliased command
     "prompt": "Open:",  # Prompt
+    "interactive_shell": False,  # Run commands in interactive mode
 }
 
 
@@ -750,7 +751,10 @@ class dmenu(object):
             print("Command converted into:")
             print(command)
 
-        return subprocess.call(command)
+        if self.prefs["interactive_shell"] is True:
+            shell = os.environ.get('SHELL', "/bin/bash")
+            command = shell + " -i -c " + " ".join(command)
+        return subprocess.call(command, shell=self.prefs["interactive_shell"])
 
     def cache_regenerate(self, message=True):
         if message:

--- a/src/dmenu_extended/main.py
+++ b/src/dmenu_extended/main.py
@@ -203,7 +203,7 @@ default_prefs = {
     "indicator_edit": "*",  # Symbol to indicate an item will launch an editor
     "indicator_alias": "",  # Symbol to indicate an aliased command
     "prompt": "Open:",  # Prompt
-    "interactive_shell": False,  # Run commands in interactive mode
+    "interactive_shell": False,  # Run commands in an interactive shell session
 }
 
 
@@ -752,7 +752,7 @@ class dmenu(object):
             print(command)
 
         if self.prefs["interactive_shell"] is True:
-            shell = os.environ.get("SHELL", "/bin/bash")
+            shell = os.environ.get("SHELL", "/usr/bin/env bash")
             command = shell + " -i -c " + " ".join(command)
         return subprocess.call(command, shell=self.prefs["interactive_shell"])
 

--- a/src/dmenu_extended/main.py
+++ b/src/dmenu_extended/main.py
@@ -752,7 +752,7 @@ class dmenu(object):
             print(command)
 
         if self.prefs["interactive_shell"] is True:
-            shell = os.environ.get('SHELL', "/bin/bash")
+            shell = os.environ.get("SHELL", "/bin/bash")
             command = shell + " -i -c " + " ".join(command)
         return subprocess.call(command, shell=self.prefs["interactive_shell"])
 


### PR DESCRIPTION
Concerning #152 I added the functionality of executing commands via interactive shell. 
I tried to be as minimally invasive as possible by making few changes and respecting the programming style. 

By default the feature is off but by setting the "interactive_shell" property to "True" in preferences the commands are executed based on the shell set (`$SHELL` env)

This is only a first step as processes launched in the background are not shown to the user but I am working on it in my spare time. 

Anyway I am submitting these changes since I don't know when I can work on them due to my jobs.

Also finished this feature I would like to do a minimum of refactoring always free time permitting.
