### PR TITLE
Fixed interactive shell aliases params

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "dmenu_extended"
-version = "1.2.0"
+version = "1.2.1"
 authors = [
   { name="Mark Hedley Jones", email="markhedleyjones@gmail.com" },
 ]

--- a/src/dmenu_extended/main.py
+++ b/src/dmenu_extended/main.py
@@ -753,7 +753,7 @@ class dmenu(object):
 
         if self.prefs["interactive_shell"] is True:
             shell = os.environ.get("SHELL", "/usr/bin/env bash")
-            command = shell + " -i -c " + " ".join(command)
+            command = '{} -i -c "{}"'.format(shell, " ".join(command))
         return subprocess.call(command, shell=self.prefs["interactive_shell"])
 
     def cache_regenerate(self, message=True):


### PR DESCRIPTION
Simply fixed the interactive shell aliases params. Now you can pass all as a single command/alias call.