### PR TITLE
pipx installation failure fix

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ classifiers = [
     "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent",
 ]
+dependencies = ["setuptools>=61.0"]
 
 [project.scripts]
 "dmenu_extended_run" = "dmenu_extended.main:run"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "dmenu_extended"
-version = "1.2.1"
+version = "1.2.2"
 authors = [
   { name="Mark Hedley Jones", email="markhedleyjones@gmail.com" },
 ]


### PR DESCRIPTION
After successful installation of demu_extended with pipx:
```
$ pipx install 'git+https://github.com/MarkHedleyJones/dmenu-extended'
  installed package dmenu_extended 1.2.1, installed using Python 3.12.3
  These apps are now globally available
    - dmenu_extended_cache_build
    - dmenu_extended_install_systemd_service
    - dmenu_extended_run
```
I am getting following error when running it:
```
$ dmenu_extended_run                                   
Traceback (most recent call last):
  File "/home/remol/.local/bin/dmenu_extended_run", line 5, in <module>
    from dmenu_extended.main import run
  File "/home/remol/.local/pipx/venvs/dmenu-extended/lib/python3.12/site-packages/dmenu_extended/__init__.py", line 1, in <module>
    from .main import *
  File "/home/remol/.local/pipx/venvs/dmenu-extended/lib/python3.12/site-packages/dmenu_extended/main.py", line 7, in <module>
    import pkg_resources
ModuleNotFoundError: No module named 'pkg_resources'
```
The fix adds missing dependency to pyproject.toml. 