### PR TITLE
Fix UnicodeEncodeError exception handling (#160)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "dmenu_extended"
-version = "1.2.1"
+version = "1.2.2"
 authors = [
   { name="Mark Hedley Jones", email="markhedleyjones@gmail.com" },
 ]

--- a/src/dmenu_extended/main.py
+++ b/src/dmenu_extended/main.py
@@ -790,7 +790,10 @@ class dmenu(object):
                         clean = False
                         foundError = True
                         if self.debug:
-                            print("Culprit: " + item.encode('unicode_escape').decode("utf-8"))
+                            print(
+                                "Culprit: "
+                                + item.encode("unicode_escape").decode("utf-8")
+                            )
                 if clean:
                     tmp.append(item)
             if foundError:
@@ -802,7 +805,7 @@ class dmenu(object):
                     print("Offending items have been excluded from cache")
                 with open(path, "wb") as f:
                     for item in tmp:
-                        f.write(item.encode('unicode_escape') + b"\n")
+                        f.write(item.encode("unicode_escape") + b"\n")
                 return 2
             else:
                 if self.debug:

--- a/src/dmenu_extended/main.py
+++ b/src/dmenu_extended/main.py
@@ -786,11 +786,11 @@ class dmenu(object):
             for item in items:
                 clean = True
                 for char in item:
-                    if char not in string.printable:
+                    if not str.isprintable(char):
                         clean = False
                         foundError = True
                         if self.debug:
-                            print("Culprit: " + item)
+                            print("Culprit: " + item.encode('unicode_escape').decode("utf-8"))
                 if clean:
                     tmp.append(item)
             if foundError:
@@ -802,7 +802,7 @@ class dmenu(object):
                     print("Offending items have been excluded from cache")
                 with open(path, "wb") as f:
                     for item in tmp:
-                        f.write(item + "\n")
+                        f.write(item.encode('unicode_escape') + b"\n")
                 return 2
             else:
                 if self.debug:


### PR DESCRIPTION
When build_cache() encounters a UnicodeEncodeError, the original code did not escape unprintable chars and caused the cache build to fail. This patch fixes the code so that the culprit is correctly printed in debug mode.

Fixes issue #160.