### PR TITLE
Expand menu_arguments

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "dmenu_extended"
-version = "1.2.4"
+version = "1.3.0"
 authors = [
   { name="Mark Hedley Jones", email="markhedleyjones@gmail.com" },
 ]

--- a/src/dmenu_extended/main.py
+++ b/src/dmenu_extended/main.py
@@ -512,8 +512,9 @@ class dmenu(object):
     def message_open(self, message):
         self.load_preferences()
         # Expand environment variables in each argument
-        expanded_args = [os.path.expandvars(arg) 
-                         for arg in self.prefs["menu_arguments"]]
+        expanded_args = [
+            os.path.expandvars(arg) for arg in self.prefs["menu_arguments"]
+        ]
 
         self.message = subprocess.Popen(
             [self.prefs["menu"]] + expanded_args,
@@ -552,8 +553,9 @@ class dmenu(object):
             return out
         else:
             # Expand environment variables in each argument
-            expanded_args = [os.path.expandvars(arg) 
-                             for arg in self.prefs["menu_arguments"]]
+            expanded_args = [
+                os.path.expandvars(arg) for arg in self.prefs["menu_arguments"]
+            ]
             p = subprocess.Popen(
                 [self.prefs["menu"]] + expanded_args + ["-p", prompt],
                 stdin=subprocess.PIPE,

--- a/src/dmenu_extended/main.py
+++ b/src/dmenu_extended/main.py
@@ -512,7 +512,8 @@ class dmenu(object):
     def message_open(self, message):
         self.load_preferences()
         # Expand environment variables in each argument
-        expanded_args = [os.path.expandvars(arg) for arg in self.prefs["menu_arguments"]]
+        expanded_args = [os.path.expandvars(arg) 
+                         for arg in self.prefs["menu_arguments"]]
 
         self.message = subprocess.Popen(
             [self.prefs["menu"]] + expanded_args,
@@ -551,7 +552,8 @@ class dmenu(object):
             return out
         else:
             # Expand environment variables in each argument
-            expanded_args = [os.path.expandvars(arg) for arg in self.prefs["menu_arguments"]]
+            expanded_args = [os.path.expandvars(arg) 
+                             for arg in self.prefs["menu_arguments"]]
             p = subprocess.Popen(
                 [self.prefs["menu"]] + expanded_args + ["-p", prompt],
                 stdin=subprocess.PIPE,

--- a/src/dmenu_extended/main.py
+++ b/src/dmenu_extended/main.py
@@ -511,8 +511,11 @@ class dmenu(object):
 
     def message_open(self, message):
         self.load_preferences()
+        # Expand environment variables in each argument
+        expanded_args = [os.path.expandvars(arg) for arg in self.prefs["menu_arguments"]]
+
         self.message = subprocess.Popen(
-            [self.prefs["menu"]] + self.prefs["menu_arguments"],
+            [self.prefs["menu"]] + expanded_args,
             stdin=subprocess.PIPE,
             preexec_fn=os.setsid,
             text=True,
@@ -547,8 +550,10 @@ class dmenu(object):
                 print("Menu bypassed with launch argument: " + out)
             return out
         else:
+            # Expand environment variables in each argument
+            expanded_args = [os.path.expandvars(arg) for arg in self.prefs["menu_arguments"]]
             p = subprocess.Popen(
-                [self.prefs["menu"]] + self.prefs["menu_arguments"] + ["-p", prompt],
+                [self.prefs["menu"]] + expanded_args + ["-p", prompt],
                 stdin=subprocess.PIPE,
                 stdout=subprocess.PIPE,
                 text=True,


### PR DESCRIPTION
This patch expands the options specified in `menu_arguments`. This allows one to say:

```
    "menu_arguments": [
        "-dmenu",
        "-i",
        "-dpi",
        "$ROFI_DPI"
    ],
```
where `$ROFI_DPI` is a shell variable (and thereby open rofi with different DPIs on different machines).