### PR TITLE
build: add dev dependencies and fix test imports

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,14 @@ dependencies = ["setuptools>=61.0"]
 "Homepage" = "https://github.com/MarkHedleyJones/dmenu-extended"
 "Bug Tracker" = "https://github.com/MarkHedleyJones/dmenu-extended/issues"
 
+[project.optional-dependencies]
+dev = [
+    "ruff",
+    "pytest",
+    "mock",
+    "build",
+]
+
 [tool.semantic_release]
 version_toml = ["pyproject.toml:project.version"]
 branch = "main"

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,9 @@
 # Development dependencies
 ruff  # Python formatter and linter
+pytest  # Test runner
+mock  # Mocking library for tests
+build  # Build tool for creating distributions
+
 # Note: shfmt is a Go binary - install with your package manager:
 #   Arch:   sudo pacman -S shfmt
 #   Fedora: sudo dnf install shfmt

--- a/tests/test_install_systemd_service.py
+++ b/tests/test_install_systemd_service.py
@@ -2,8 +2,12 @@
 
 import os
 import shutil
+import sys
 
-import install_systemd_service
+# Add parent directory to path to import dmenu_extended
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+
+from dmenu_extended import install_systemd_service
 import mock
 import pytest
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -5,7 +5,8 @@ from os import path
 
 import mock
 
-sys.path.append(path.dirname(path.dirname(path.abspath(__file__))))
+# Add src directory to path to import dmenu_extended
+sys.path.insert(0, path.join(path.dirname(__file__), "..", "src"))
 import dmenu_extended as d
 
 menu = d.dmenu()


### PR DESCRIPTION
Adds development dependencies to support testing and build workflows.

Changes:
- Add pytest, mock, and build to requirements-dev.txt
- Add optional [dev] dependencies section to pyproject.toml
- Fix import paths in test files to work with src-layout package structure

This provides consistent tooling for running tests and building the package during development.