### PR TITLE
feat: add clipboard copy support for Rofi custom keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,13 +221,13 @@ To enable this feature, add the `-kb-custom-1` argument to your `menu_arguments`
   "-dmenu",
   "-i",
   "-kb-custom-1",
-  "Control+c"
+  "Alt+c"
 ],
 ```
 
-Now when you press Ctrl+C (or whatever key you bind), the selected entry will be copied to your clipboard and dmenu-extended will exit. You can then paste the entry elsewhere.
+Now when you press Alt+C (or whatever key you bind), the selected entry will be copied to your clipboard and dmenu-extended will exit. You can then paste the entry elsewhere.
 
-**Note:** This feature is only available when using Rofi. Standard dmenu does not support custom key bindings.
+**Note:** This feature is only available when using Rofi. Standard dmenu does not support custom key bindings. Some key combinations like `Control+c` are already bound by Rofi and cannot be used for custom bindings.
 
 ## Advanced usage
 

--- a/README.md
+++ b/README.md
@@ -206,6 +206,29 @@ You may also need to add
 
 to remove the extra colon depending on your Rofi version.
 
+### Copying entries to clipboard with Rofi
+
+When using Rofi, you can configure a custom key binding to copy the currently selected menu entry to the clipboard instead of executing it. This requires:
+
+1. A clipboard tool installed (`wl-copy` for Wayland, or `xclip`/`xsel` for X11)
+2. Rofi configured with a custom key binding
+
+To enable this feature, add the `-kb-custom-1` argument to your `menu_arguments`:
+
+```json
+"menu": "rofi",
+"menu_arguments": [
+  "-dmenu",
+  "-i",
+  "-kb-custom-1",
+  "Control+c"
+],
+```
+
+Now when you press Ctrl+C (or whatever key you bind), the selected entry will be copied to your clipboard and dmenu-extended will exit. You can then paste the entry elsewhere.
+
+**Note:** This feature is only available when using Rofi. Standard dmenu does not support custom key bindings.
+
 ## Advanced usage
 
 Dmenu-extended understands the following modifier characters when entering a special command:

--- a/src/dmenu_extended/main.py
+++ b/src/dmenu_extended/main.py
@@ -572,12 +572,12 @@ class dmenu(object):
                         stdout=subprocess.DEVNULL,
                         stderr=subprocess.DEVNULL,
                     )
-                if self.debug:
+                if debug:
                     print(f"Copied to clipboard using {tool}: {text}")
                 return True
             except (FileNotFoundError, subprocess.CalledProcessError):
                 continue
-        if self.debug:
+        if debug:
             print("Warning: No clipboard tool found (tried wl-copy, xclip, xsel)")
         return False
 

--- a/src/dmenu_extended/main.py
+++ b/src/dmenu_extended/main.py
@@ -541,6 +541,46 @@ class dmenu(object):
                 command[index] = item.format(prompt=prompt)
         return self.command_output(command)
 
+    def copy_to_clipboard(self, text):
+        clipboard_tools = ["wl-copy", "xclip", "xsel"]
+        for tool in clipboard_tools:
+            try:
+                if tool == "xclip":
+                    subprocess.run(
+                        [tool, "-selection", "clipboard"],
+                        input=text,
+                        text=True,
+                        check=True,
+                        stdout=subprocess.DEVNULL,
+                        stderr=subprocess.DEVNULL,
+                    )
+                elif tool == "xsel":
+                    subprocess.run(
+                        [tool, "--clipboard", "--input"],
+                        input=text,
+                        text=True,
+                        check=True,
+                        stdout=subprocess.DEVNULL,
+                        stderr=subprocess.DEVNULL,
+                    )
+                else:
+                    subprocess.run(
+                        [tool],
+                        input=text,
+                        text=True,
+                        check=True,
+                        stdout=subprocess.DEVNULL,
+                        stderr=subprocess.DEVNULL,
+                    )
+                if self.debug:
+                    print(f"Copied to clipboard using {tool}: {text}")
+                return True
+            except (FileNotFoundError, subprocess.CalledProcessError):
+                continue
+        if self.debug:
+            print("Warning: No clipboard tool found (tried wl-copy, xclip, xsel)")
+        return False
+
     def menu(self, items, prompt=""):
         global debug
         self.load_preferences()
@@ -569,6 +609,12 @@ class dmenu(object):
             out = p.communicate(items)[0]
             out = out.strip("\n")
             out = out.strip()
+
+            # Handle rofi custom key (exit code 10) - copy to clipboard
+            if p.returncode == 10:
+                if len(out) > 0:
+                    self.copy_to_clipboard(out)
+                sys.exit()
 
             if len(out) == 0:
                 sys.exit()


### PR DESCRIPTION
## Summary

Adds support for copying selected menu entries to the clipboard when using Rofi, triggered by a custom key binding.

## Changes

- Added `copy_to_clipboard()` method that supports multiple clipboard tools (`wl-copy`, `xclip`, `xsel`)
- Handle Rofi's custom key exit code (10) to copy selected entry instead of executing it
- Added comprehensive tests for clipboard functionality
- Updated documentation with usage instructions

## Usage

Users can configure a custom key binding in their Rofi menu arguments:

```json
"menu": "rofi",
"menu_arguments": [
  "-dmenu",
  "-i",
  "-kb-custom-1",
  "Alt+c"
],
```

When the custom key is pressed (Alt+C in the example), the selected entry is copied to the clipboard and dmenu-extended exits without executing the entry.

## Requirements

Requires one of the following clipboard tools to be installed:
- wl-copy (Wayland)
- xclip (X11)
- xsel (X11)


## Testing

Run the test suite to verify functionality:
python -m pytest tests/test_main.py -v

## Notes

- This feature is only available when using Rofi (standard dmenu doesn't support custom key bindings)
- Some key combinations like Control+c are already bound by Rofi and cannot be used for custom bindings