### PR TITLE
fix: re-add environment variable expansion in menu_arguments

### DIFF
--- a/src/dmenu_extended/main.py
+++ b/src/dmenu_extended/main.py
@@ -515,8 +515,11 @@ class dmenu(object):
 
     def message_open(self, message):
         self.load_preferences()
+        expanded_args = [
+            os.path.expandvars(arg) for arg in self.prefs["menu_arguments"]
+        ]
         self.message = subprocess.Popen(
-            [self.prefs["menu"]] + self.prefs["menu_arguments"],
+            [self.prefs["menu"]] + expanded_args,
             stdin=subprocess.PIPE,
             preexec_fn=os.setsid,
             text=True,
@@ -592,8 +595,11 @@ class dmenu(object):
                 print("Menu bypassed with launch argument: " + out)
             return out
         else:
+            expanded_args = [
+                os.path.expandvars(arg) for arg in self.prefs["menu_arguments"]
+            ]
             p = subprocess.Popen(
-                [self.prefs["menu"]] + self.prefs["menu_arguments"] + ["-p", prompt],
+                [self.prefs["menu"]] + expanded_args + ["-p", prompt],
                 stdin=subprocess.PIPE,
                 stdout=subprocess.PIPE,
                 text=True,


### PR DESCRIPTION
## Summary

- Re-adds `os.path.expandvars()` for `menu_arguments` entries in both `message_open()` and `menu()` methods
- This was accidentally removed in commit 548ba38 ("Reformat code fix CI jobs") which overwrote the changes from PR #166
- Allows shell variables like `$ROFI_DPI` to be used in `menu_arguments`

Fixes the regression reported in https://github.com/markhedleyjones/dmenu-extended/pull/166#issuecomment-3843672415