### PR TITLE
fix: replace removed pkg_resources with importlib.metadata

### DIFF
--- a/src/dmenu_extended/main.py
+++ b/src/dmenu_extended/main.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import importlib
+import importlib.metadata
 import json
 import operator
 import os
@@ -9,8 +10,6 @@ import subprocess
 import sys
 import time
 import urllib.request
-
-import pkg_resources
 
 Help = """
 Dmenu Extended command line options
@@ -66,7 +65,7 @@ class Version:
 
 
 provided_package_versions = {
-    "dmenu-extended": Version(pkg_resources.get_distribution("dmenu-extended").version),
+    "dmenu-extended": Version(importlib.metadata.version("dmenu-extended")),
     "python": Version(".".join(map(str, sys.version_info[:3]))),
 }
 


### PR DESCRIPTION
## Problem
`main.py` imported `pkg_resources` (shipped by setuptools) purely to read the installed distribution version. `pkg_resources` is deprecated and is no longer importable on Python 3.12+, so the module fails to import outright on newer interpreters with `ModuleNotFoundError: No module named 'pkg_resources'`.

The CI `system-test` image is built `FROM python:3-slim`, which is unpinned and has since advanced to Python 3.14. That is why the test suite was green earlier in the year and is red now despite no relevant code change - the interpreter drifted underneath it.

## Fix
Use `importlib.metadata.version("dmenu-extended")`, which is in the standard library since Python 3.8 and returns the same version string, then drop the `pkg_resources` import.

## Verification
- `ruff check` and `ruff format --check` pass.
- `importlib.metadata.version("dmenu-extended")` resolves the installed version locally.
- The module imports end to end.

## Note
The underlying cause (an unpinned `python:3-slim` base image) can resurface in other ways as Python advances; pinning the test image to a specific minor version would make CI deterministic. Left out of this change to keep it focused.