### PR TITLE
test: characterisation safety net before plugin-system refactor

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ An extension to the original [dmenu](http://tools.suckless.org/dmenu/) allowing 
 
 ### Dependencies
 
-- **Python** - version 3.8 or higher
+- **Python** - version 3.9 or higher
 - **dmenu** - version 4.5 or later
 
 Quick dependency install:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ authors = [
 description = "A wrapper for dmenu that implements plugins and fast file/folder searching"
 readme = "README.md"
 license = { text="MIT" }
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 classifiers = [
     "Programming Language :: Python :: 3",
     "License :: OSI Approved :: MIT License",

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -1,0 +1,511 @@
+#!/usr/bin/env python3
+
+"""Characterisation tests for the cache machinery in dmenu_extended.main.
+
+These pin down the CURRENT behaviour of build_cache, cache_load, cache_save,
+cache_open, cache_regenerate, scan_binaries, scan_applications, system_path and
+the include/exclude/ignore/alias preferences that shape the cache. The
+filesystem is redirected into a temporary directory via the
+DMENU_EXTENDED_CACHE_DIR environment variable, and every boundary that would
+touch the real system (binary scan, application scan, plugins, subprocess) is
+mocked.
+"""
+
+import json
+import os
+import shutil
+import sys
+import tempfile
+import unittest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+
+from dmenu_extended import main
+import mock
+
+
+class CacheTestBase(unittest.TestCase):
+    """Redirect cache files into a temp dir and give a fresh dmenu instance.
+
+    The module reads DMENU_EXTENDED_CACHE_DIR at import time to choose
+    path_cache, so we set it, reload the module, then re-point the module-level
+    file_cache_* globals (mirroring tests/test_frequently_used_cleanup.py).
+    """
+
+    def setUp(self):
+        self.test_dir = tempfile.mkdtemp()
+        self._orig_cache_dir = os.environ.get("DMENU_EXTENDED_CACHE_DIR")
+        os.environ["DMENU_EXTENDED_CACHE_DIR"] = self.test_dir
+
+        import importlib
+
+        importlib.reload(main)
+
+        self._repoint_cache_globals()
+
+        self.dmenu = main.dmenu()
+        # Avoid sharing class-level prefs between instances/tests.
+        self.dmenu.prefs = dict(main.default_prefs)
+
+    def tearDown(self):
+        if self._orig_cache_dir is not None:
+            os.environ["DMENU_EXTENDED_CACHE_DIR"] = self._orig_cache_dir
+        else:
+            os.environ.pop("DMENU_EXTENDED_CACHE_DIR", None)
+
+        import importlib
+
+        importlib.reload(main)
+        shutil.rmtree(self.test_dir, ignore_errors=True)
+
+    def _repoint_cache_globals(self):
+        c = main.path_cache
+        main.file_cache = c + "/dmenuExtended_all.txt"
+        main.file_cache_binaries = c + "/dmenuExtended_binaries.txt"
+        main.file_cache_files = c + "/dmenuExtended_files.txt"
+        main.file_cache_folders = c + "/dmenuExtended_folders.txt"
+        main.file_cache_aliases = c + "/dmenuExtended_aliases.txt"
+        main.file_cache_aliasesLookup = c + "/dmenuExtended_aliases_lookup.json"
+        main.file_cache_plugins = c + "/dmenuExtended_plugins.txt"
+        main.file_cache_frequentlyUsed_frequency = (
+            c + "/dmenuExtended_frequentlyUsed_frequency.json"
+        )
+        main.file_cache_frequentlyUsed_ordered = (
+            c + "/dmenuExtended_frequentlyUsed_ordered.json"
+        )
+
+
+# ---------------------------------------------------------------------------
+# cache_save / cache_open round-trips
+# ---------------------------------------------------------------------------
+
+
+class TestCacheSaveOpen(CacheTestBase):
+    def test_save_list_writes_newline_terminated_lines(self):
+        path = os.path.join(self.test_dir, "list.txt")
+        result = self.dmenu.cache_save(["alpha", "beta", "gamma"], path)
+        # Returns 1 on the normal path.
+        self.assertEqual(result, 1)
+        with open(path) as f:
+            self.assertEqual(f.read(), "alpha\nbeta\ngamma\n")
+
+    def test_save_string_written_verbatim(self):
+        path = os.path.join(self.test_dir, "str.txt")
+        # A plain string is written as-is, with no added trailing newline.
+        result = self.dmenu.cache_save("just a string", path)
+        self.assertEqual(result, 1)
+        with open(path) as f:
+            self.assertEqual(f.read(), "just a string")
+
+    def test_open_returns_full_file_contents_as_string(self):
+        path = os.path.join(self.test_dir, "round.txt")
+        self.dmenu.cache_save(["one", "two"], path)
+        # cache_open returns the raw text including trailing newline, not a list.
+        self.assertEqual(self.dmenu.cache_open(path), "one\ntwo\n")
+
+    def test_open_missing_file_returns_false(self):
+        missing = os.path.join(self.test_dir, "does_not_exist.txt")
+        self.assertIs(self.dmenu.cache_open(missing), False)
+
+    def test_save_non_printable_excludes_offending_items_returns_2(self):
+        # A surrogate cannot be encoded to the default locale on write, which
+        # trips the UnicodeEncodeError branch; offending lines are dropped and
+        # the remainder written unicode-escaped. Return code is 2.
+        path = os.path.join(self.test_dir, "bad.txt")
+        items = ["clean", "ba\udcffd"]
+        result = self.dmenu.cache_save(items, path)
+        self.assertEqual(result, 2)
+        with open(path, "rb") as f:
+            data = f.read()
+        # Only the clean item is written; the offending one is dropped entirely.
+        self.assertEqual(data, b"clean\n")
+
+
+# ---------------------------------------------------------------------------
+# system_path
+# ---------------------------------------------------------------------------
+
+
+class TestSystemPath(CacheTestBase):
+    def test_dedupes_and_drops_empty_entries(self):
+        with mock.patch.dict(os.environ, {"PATH": "/bin:/usr/bin:/bin::"}):
+            result = self.dmenu.system_path()
+        self.assertIsInstance(result, list)
+        self.assertNotIn("", result)
+        # Deduplicated: /bin appears once despite being listed twice.
+        self.assertEqual(sorted(result), ["/bin", "/usr/bin"])
+
+
+# ---------------------------------------------------------------------------
+# scan_binaries
+# ---------------------------------------------------------------------------
+
+
+class TestScanBinaries(CacheTestBase):
+    def test_lists_directory_contents_and_skips_gpk_prefixed(self):
+        bindir = os.path.join(self.test_dir, "bin")
+        os.makedirs(bindir)
+        for name in ["firefox", "htop", "gpk-application", "gpkother"]:
+            open(os.path.join(bindir, name), "w").close()
+
+        with mock.patch.object(self.dmenu, "system_path", lambda: [bindir]):
+            result = self.dmenu.scan_binaries()
+
+        self.assertIn("firefox", result)
+        self.assertIn("htop", result)
+        # Anything whose first three characters are "gpk" is filtered out.
+        self.assertNotIn("gpk-application", result)
+        self.assertNotIn("gpkother", result)
+
+    def test_path_entry_that_is_a_file_is_appended_directly(self):
+        # When a PATH entry is itself a file (not a directory), the full path is
+        # appended verbatim rather than its contents listed.
+        filepath = os.path.join(self.test_dir, "a_file")
+        open(filepath, "w").close()
+        with mock.patch.object(self.dmenu, "system_path", lambda: [filepath]):
+            result = self.dmenu.scan_binaries()
+        self.assertEqual(result, [filepath])
+
+
+# ---------------------------------------------------------------------------
+# scan_applications (parsing .desktop files)
+# ---------------------------------------------------------------------------
+
+
+class TestScanApplications(CacheTestBase):
+    def _write_desktop(self, dirpath, filename, contents):
+        os.makedirs(dirpath, exist_ok=True)
+        with open(os.path.join(dirpath, filename), "w") as f:
+            f.write(contents)
+
+    def test_parses_name_command_terminal_and_descriptor(self):
+        appdir = os.path.join(self.test_dir, "applications")
+        self._write_desktop(
+            appdir,
+            "firefox.desktop",
+            "[Desktop Entry]\nName=Firefox\nGenericName=Web Browser\n"
+            "Exec=firefox %u\nTerminal=false\n",
+        )
+        with (
+            mock.patch.object(self.dmenu, "application_paths", lambda: [appdir]),
+            mock.patch.object(self.dmenu, "system_path", lambda: []),
+        ):
+            apps = self.dmenu.scan_applications()
+
+        self.assertEqual(len(apps), 1)
+        app = apps[0]
+        self.assertEqual(app["name"], "Firefox")
+        self.assertEqual(app["name_generic"], "Web Browser")
+        # The "%u" field code and everything after it is stripped from Exec.
+        self.assertEqual(app["command"], "firefox")
+        self.assertIs(app["terminal"], False)
+        # descriptor is the filename minus the .desktop suffix.
+        self.assertEqual(app["descriptor"], "firefox")
+
+    def test_terminal_true_recorded_and_generic_defaults_to_name(self):
+        appdir = os.path.join(self.test_dir, "applications")
+        self._write_desktop(
+            appdir,
+            "htop.desktop",
+            "[Desktop Entry]\nName=Htop\nExec=htop\nTerminal=True\n",
+        )
+        with (
+            mock.patch.object(self.dmenu, "application_paths", lambda: [appdir]),
+            mock.patch.object(self.dmenu, "system_path", lambda: []),
+        ):
+            apps = self.dmenu.scan_applications()
+
+        self.assertEqual(len(apps), 1)
+        self.assertIs(apps[0]["terminal"], True)
+        # With no GenericName line, name_generic falls back to name.
+        self.assertEqual(apps[0]["name_generic"], "Htop")
+
+    def test_entry_missing_exec_or_name_is_skipped(self):
+        appdir = os.path.join(self.test_dir, "applications")
+        self._write_desktop(appdir, "noexec.desktop", "[Desktop Entry]\nName=NoExec\n")
+        self._write_desktop(appdir, "noname.desktop", "[Desktop Entry]\nExec=mystery\n")
+        with (
+            mock.patch.object(self.dmenu, "application_paths", lambda: [appdir]),
+            mock.patch.object(self.dmenu, "system_path", lambda: []),
+        ):
+            apps = self.dmenu.scan_applications()
+        # Both entries lack one of the required Name/Exec pair, so neither is kept.
+        self.assertEqual(apps, [])
+
+    def test_command_with_absolute_path_in_system_path_is_shortened(self):
+        appdir = os.path.join(self.test_dir, "applications")
+        self._write_desktop(
+            appdir,
+            "tool.desktop",
+            "[Desktop Entry]\nName=Tool\nExec=/usr/bin/tool\nTerminal=false\n",
+        )
+        with (
+            mock.patch.object(self.dmenu, "application_paths", lambda: [appdir]),
+            mock.patch.object(self.dmenu, "system_path", lambda: ["/usr/bin"]),
+        ):
+            apps = self.dmenu.scan_applications()
+        # The leading "/usr/bin/" is stripped because the bare name has no slash.
+        self.assertEqual(apps[0]["command"], "tool")
+
+
+# ---------------------------------------------------------------------------
+# alias file parsing (path_aliasFile)
+# ---------------------------------------------------------------------------
+
+
+class TestParseAliasFile(CacheTestBase):
+    def test_parses_alias_lines_and_strips_matching_outer_quotes(self):
+        alias_path = os.path.join(self.test_dir, ".bash_aliases")
+        with open(alias_path, "w") as f:
+            f.write(
+                'alias ll="ls -la"\n'
+                "alias gs='git status'\n"
+                "# a comment line\n"
+                "export FOO=bar\n"
+                "alias gp=git push\n"
+            )
+        result = self.dmenu.parse_alias_file(alias_path)
+        # Only "alias " lines are parsed; comments and exports are ignored.
+        self.assertEqual(
+            result,
+            [
+                ["ll", "ls -la"],
+                ["gs", "git status"],
+                ["gp", "git push"],
+            ],
+        )
+
+    def test_preserves_interior_equals_in_command(self):
+        alias_path = os.path.join(self.test_dir, ".bash_aliases")
+        with open(alias_path, "w") as f:
+            f.write('alias setx="export X=1"\n')
+        result = self.dmenu.parse_alias_file(alias_path)
+        # The value is re-joined on "=" so interior equals signs survive.
+        self.assertEqual(result, [["setx", "export X=1"]])
+
+
+# ---------------------------------------------------------------------------
+# build_cache: how include/exclude/ignore/alias prefs shape the output
+# ---------------------------------------------------------------------------
+
+
+class TestBuildCache(CacheTestBase):
+    def _run_build(self, prefs_overrides=None):
+        """Run build_cache with all expensive boundaries stubbed out.
+
+        Returns the cache_load() text after the build. Plugins are forced to an
+        empty list, the filesystem walk is suppressed by pointing watch_folders
+        at an empty temp directory, and binary/application scans are controlled
+        per-test via the supplied prefs.
+        """
+        self.dmenu.prefs.update(prefs_overrides or {})
+        # An empty watch folder so os.walk yields nothing (no real home scan).
+        empty = os.path.join(self.test_dir, "watch_empty")
+        os.makedirs(empty, exist_ok=True)
+        self.dmenu.prefs["watch_folders"] = [empty]
+
+        # message_open/message_close spawn the real menu (dmenu) for progress
+        # UI; stub them so neither the build nor a cache_load-triggered
+        # regenerate shells out. plugins_available is stubbed only around
+        # build_cache - cache_load needs the real one so it writes the plugins
+        # cache file (otherwise cache_load hits its exitOnFail sys.exit).
+        with (
+            mock.patch.object(self.dmenu, "message_open"),
+            mock.patch.object(self.dmenu, "message_close"),
+        ):
+            with mock.patch.object(self.dmenu, "plugins_available", lambda: []):
+                self.dmenu.build_cache()
+            return self.dmenu.cache_load()
+
+    def test_binaries_excluded_by_default(self):
+        # include_binaries defaults to False, so scan_binaries is never invoked
+        # and no binary appears in the cache.
+        with (
+            mock.patch.object(
+                self.dmenu, "scan_binaries", lambda: ["should_not_appear"]
+            ),
+            mock.patch.object(self.dmenu, "scan_applications", lambda: []),
+        ):
+            text = self._run_build({"include_applications": False})
+        self.assertNotIn("should_not_appear", text)
+
+    def test_include_binaries_true_adds_binaries(self):
+        with (
+            mock.patch.object(self.dmenu, "scan_binaries", lambda: ["firefox", "htop"]),
+            mock.patch.object(self.dmenu, "scan_applications", lambda: []),
+        ):
+            text = self._run_build(
+                {"include_binaries": True, "include_applications": False}
+            )
+        self.assertIn("firefox", text)
+        self.assertIn("htop", text)
+
+    def test_include_items_appended_to_cache(self):
+        with mock.patch.object(self.dmenu, "scan_applications", lambda: []):
+            text = self._run_build(
+                {
+                    "include_applications": False,
+                    "include_items": ["my custom entry"],
+                }
+            )
+        self.assertIn("my custom entry", text)
+
+    def test_exclude_items_removed_from_cache(self):
+        with (
+            mock.patch.object(
+                self.dmenu, "scan_binaries", lambda: ["keepme", "dropme"]
+            ),
+            mock.patch.object(self.dmenu, "scan_applications", lambda: []),
+        ):
+            text = self._run_build(
+                {
+                    "include_binaries": True,
+                    "include_applications": False,
+                    "exclude_items": ["dropme"],
+                }
+            )
+        self.assertIn("keepme", text)
+        self.assertNotIn("dropme", text)
+
+    def test_rebuild_cache_sentinel_always_present(self):
+        with mock.patch.object(self.dmenu, "scan_applications", lambda: []):
+            text = self._run_build({"include_applications": False})
+        # build_cache always appends a literal "rebuild cache" entry.
+        self.assertIn("rebuild cache", text)
+
+    def test_aliased_application_writes_lookup_and_aliases_files(self):
+        apps = [
+            {
+                "name": "Htop",
+                "name_generic": "Process Viewer",
+                "command": "htop",
+                "terminal": True,
+                "descriptor": "htop",
+            }
+        ]
+        with (
+            mock.patch.object(self.dmenu, "scan_applications", lambda: apps),
+            mock.patch.object(self.dmenu, "scan_binaries", lambda: []),
+        ):
+            text = self._run_build(
+                {
+                    "include_applications": True,
+                    "alias_applications": True,
+                    "include_binaries": False,
+                }
+            )
+        # Default alias_display_format is "{name}" and indicator_alias is empty,
+        # so the displayed item is just the application name.
+        self.assertIn("Htop", text)
+
+        # The lookup file maps the displayed title to the real command, and a
+        # terminal app gets a trailing ";" appended to its command.
+        with open(main.file_cache_aliasesLookup) as f:
+            lookup = json.load(f)
+        self.assertEqual(lookup, [["Htop", "htop;"]])
+
+    def test_include_items_alias_pair_added_as_alias(self):
+        # A two-element list in include_items is treated as an [name, command]
+        # alias, not a plain string entry.
+        with (
+            mock.patch.object(self.dmenu, "scan_applications", lambda: []),
+            mock.patch.object(self.dmenu, "scan_binaries", lambda: []),
+        ):
+            text = self._run_build(
+                {
+                    "include_applications": False,
+                    "include_items": [["My Editor", "vim"]],
+                }
+            )
+        self.assertIn("My Editor", text)
+        with open(main.file_cache_aliasesLookup) as f:
+            lookup = json.load(f)
+        self.assertIn(["My Editor", "vim"], lookup)
+
+    def test_path_alias_file_entries_folded_into_cache(self):
+        alias_path = os.path.join(self.test_dir, "myaliases")
+        with open(alias_path, "w") as f:
+            f.write('alias ll="ls -la"\n')
+        with (
+            mock.patch.object(self.dmenu, "scan_applications", lambda: []),
+            mock.patch.object(self.dmenu, "scan_binaries", lambda: []),
+        ):
+            text = self._run_build(
+                {
+                    "include_applications": False,
+                    "path_aliasFile": alias_path,
+                }
+            )
+        # The alias name (formatted via "{name}") is present in the cache.
+        self.assertIn("ll", text)
+        with open(main.file_cache_aliasesLookup) as f:
+            lookup = json.load(f)
+        self.assertIn(["ll", "ls -la"], lookup)
+
+    def test_include_item_with_trailing_semicolon_drops_plain_binary(self):
+        # If a binary "htop" exists and an include_item "htop;" is supplied, the
+        # non-semicolon binary form is removed in favour of the terminal form.
+        with (
+            mock.patch.object(self.dmenu, "scan_binaries", lambda: ["htop"]),
+            mock.patch.object(self.dmenu, "scan_applications", lambda: []),
+        ):
+            text = self._run_build(
+                {
+                    "include_binaries": True,
+                    "include_applications": False,
+                    "include_items": ["htop;"],
+                }
+            )
+        lines = text.split("\n")
+        self.assertIn("htop;", lines)
+        self.assertNotIn("htop", lines)
+
+
+# ---------------------------------------------------------------------------
+# cache_load / cache_regenerate behaviour
+# ---------------------------------------------------------------------------
+
+
+class TestCacheLoad(CacheTestBase):
+    def test_regenerates_when_scanned_cache_missing(self):
+        # With no cache files present, cache_load triggers cache_regenerate,
+        # which we intercept to write a minimal cache, then it re-reads.
+        self.dmenu.prefs = dict(main.default_prefs)
+
+        def fake_regenerate(message=True):
+            self.dmenu.cache_save(["plugin item"], main.file_cache_plugins)
+            self.dmenu.cache_save(["scanned item"], main.file_cache)
+            return True
+
+        with mock.patch.object(self.dmenu, "cache_regenerate", fake_regenerate):
+            text = self.dmenu.cache_load()
+
+        self.assertIn("scanned item", text)
+        # Settings entry is injected using the indicator_submenu prefix.
+        self.assertIn("Settings", text)
+
+    def test_show_scanned_false_omits_scanned_entries(self):
+        self.dmenu.prefs = dict(main.default_prefs)
+        self.dmenu.cache_save(["plugin item"], main.file_cache_plugins)
+        self.dmenu.cache_save(["scanned item"], main.file_cache)
+        self.dmenu.show_scanned = False
+        text = self.dmenu.cache_load()
+        self.assertNotIn("scanned item", text)
+
+    def test_show_settings_false_puts_settings_last(self):
+        self.dmenu.prefs = dict(main.default_prefs)
+        self.dmenu.cache_save([], main.file_cache_plugins)
+        self.dmenu.cache_save(["scanned item"], main.file_cache)
+        self.dmenu.show_settings = False
+        text = self.dmenu.cache_load()
+        # When show_settings is False the Settings entry is appended at the end.
+        self.assertTrue(text.rstrip("\n").endswith("Settings"))
+
+    def test_cache_regenerate_without_message_calls_build_cache(self):
+        with mock.patch.object(self.dmenu, "build_cache", lambda: ["built"]) as _:
+            result = self.dmenu.cache_regenerate(message=False)
+        self.assertEqual(result, ["built"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_execute.py
+++ b/tests/test_execute.py
@@ -1,0 +1,408 @@
+#!/usr/bin/env python3
+"""Characterisation tests for the execution paths of dmenu-extended.
+
+These tests pin down the CURRENT behaviour of execute(), command_to_list(),
+open_terminal(), open_url(), open_in_terminal_editor() and the special modifier
+characters handled by handle_command() (the '@', ';' and ';;' suffixes plus the
+path/url/binary dispatch). Boundaries (subprocess.call, the shell-command file
+on disk, os.chmod and scan_binaries) are mocked - no real terminal, browser or
+menu is ever launched.
+
+Note: several of these behaviours are quirky (e.g. fork appends a literal '&'
+argument to the argv list rather than detaching the process, and open_url
+percent-encodes spaces in the path portion too). Characterisation tests assert
+what the code does today, not what it arguably ought to do.
+"""
+
+import contextlib
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+
+import mock  # noqa: E402
+import pytest  # noqa: E402
+
+from dmenu_extended import main  # noqa: E402
+
+
+def make_menu(**pref_overrides):
+    """Return a dmenu instance with prefs pre-populated.
+
+    Pre-setting ``prefs`` to a dict makes load_preferences() a no-op, so none of
+    the code under test reads the user's real config from disk.
+    """
+    menu = main.dmenu()
+    prefs = dict(main.default_prefs)
+    prefs.update(pref_overrides)
+    menu.prefs = prefs
+    menu.preCommand = False
+    return menu
+
+
+# ---------------------------------------------------------------------------
+# execute()
+# ---------------------------------------------------------------------------
+
+
+def test_execute_basic_splits_into_argv():
+    menu = make_menu(interactive_shell=False)
+    with mock.patch("subprocess.call") as call:
+        call.return_value = 0
+        rc = menu.execute("firefox --new-window")
+    call.assert_called_once_with(["firefox", "--new-window"])
+    assert rc == 0
+
+
+def test_execute_fork_appends_literal_ampersand_argument():
+    # fork=True does NOT detach the process; it appends a literal "&" arg.
+    menu = make_menu(interactive_shell=False)
+    with mock.patch("subprocess.call") as call:
+        menu.execute("firefox", fork=True)
+    call.assert_called_once_with(["firefox", "&"])
+
+
+def test_execute_default_fork_none_does_not_append_ampersand():
+    menu = make_menu(interactive_shell=False)
+    with mock.patch("subprocess.call") as call:
+        menu.execute("firefox")
+    call.assert_called_once_with(["firefox"])
+
+
+def test_execute_precommand_is_prepended():
+    menu = make_menu(interactive_shell=False)
+    menu.preCommand = "sudo"
+    with mock.patch("subprocess.call") as call:
+        menu.execute("reboot")
+    call.assert_called_once_with(["sudo", "reboot"])
+
+
+def test_execute_precommand_and_fork_combined_order():
+    # preCommand goes first, then the command, then the trailing "&".
+    menu = make_menu(interactive_shell=False)
+    menu.preCommand = "sudo"
+    with mock.patch("subprocess.call") as call:
+        menu.execute("reboot", fork=True)
+    call.assert_called_once_with(["sudo", "reboot", "&"])
+
+
+def test_execute_interactive_shell_joins_into_single_string():
+    menu = make_menu(interactive_shell=True)
+    with (
+        mock.patch("subprocess.call") as call,
+        mock.patch.dict(os.environ, {"SHELL": "/bin/zsh"}),
+    ):
+        menu.execute("firefox --new-window")
+    call.assert_called_once_with(["/bin/zsh", "-i", "-c", "firefox --new-window"])
+
+
+def test_execute_interactive_shell_falls_back_to_bin_sh():
+    menu = make_menu(interactive_shell=True)
+    env = dict(os.environ)
+    env.pop("SHELL", None)
+    with (
+        mock.patch("subprocess.call") as call,
+        mock.patch.dict(os.environ, env, clear=True),
+    ):
+        menu.execute("ls")
+    call.assert_called_once_with(["/bin/sh", "-i", "-c", "ls"])
+
+
+def test_execute_interactive_shell_fork_ampersand_is_inside_joined_string():
+    # With fork=True the "&" is appended as a list element, then joined into the
+    # single shell string - so it becomes a trailing " &" in the -c argument.
+    menu = make_menu(interactive_shell=True)
+    with (
+        mock.patch("subprocess.call") as call,
+        mock.patch.dict(os.environ, {"SHELL": "/bin/bash"}),
+    ):
+        menu.execute("firefox", fork=True)
+    call.assert_called_once_with(["/bin/bash", "-i", "-c", "firefox &"])
+
+
+# ---------------------------------------------------------------------------
+# command_to_list() - coverage gaps not already in tests/test_main.py
+# (single-quote handling and odd-quote-count behaviour)
+# ---------------------------------------------------------------------------
+
+
+def test_command_to_list_single_quotes_rejoined_and_stripped():
+    menu = make_menu()
+    assert menu.command_to_list("vim '/home/user/my file.txt'") == [
+        "vim",
+        "/home/user/my file.txt",
+    ]
+
+
+def test_command_to_list_odd_double_quote_count_left_untouched():
+    # An odd number of double quotes skips the rejoin/strip logic entirely, so
+    # the stray quote survives in the output.
+    menu = make_menu()
+    assert menu.command_to_list('echo "hello') == ["echo", '"hello']
+
+
+def test_command_to_list_non_string_non_list_returns_empty():
+    menu = make_menu()
+    assert menu.command_to_list(None) == []
+    assert menu.command_to_list(123) == []
+
+
+# ---------------------------------------------------------------------------
+# open_terminal() - writes the shell-command file, chmods it, then runs it
+# ---------------------------------------------------------------------------
+
+
+def test_open_terminal_direct_runs_sh_e(tmp_path):
+    sh_file = tmp_path / "shellCommand.sh"
+    menu = make_menu(path_shellCommand=str(sh_file), terminal="xterm")
+    with mock.patch("subprocess.call") as call:
+        menu.open_terminal("htop", direct=True)
+
+    # The generated script is written to disk with a bash shebang + the command.
+    contents = sh_file.read_text()
+    assert contents == "#! /bin/bash\nhtop\n"
+    # direct=True invokes the script straight through sh -e, not the terminal.
+    call.assert_called_once_with(["sh", "-e", str(sh_file)])
+
+
+def test_open_terminal_non_direct_uses_terminal_with_dash_e(tmp_path):
+    sh_file = tmp_path / "shellCommand.sh"
+    menu = make_menu(path_shellCommand=str(sh_file), terminal="xterm")
+    with mock.patch("subprocess.call") as call:
+        menu.open_terminal("htop")
+    call.assert_called_once_with(["xterm", "-e", str(sh_file)])
+
+
+def test_open_terminal_terminal_pref_is_shlex_split(tmp_path):
+    # A multi-word terminal preference is shlex-split, not passed as one arg.
+    sh_file = tmp_path / "shellCommand.sh"
+    menu = make_menu(path_shellCommand=str(sh_file), terminal="gnome-terminal --tab")
+    with mock.patch("subprocess.call") as call:
+        menu.open_terminal("htop")
+    call.assert_called_once_with(["gnome-terminal", "--tab", "-e", str(sh_file)])
+
+
+def test_open_terminal_hold_appends_pause_lines(tmp_path):
+    sh_file = tmp_path / "shellCommand.sh"
+    menu = make_menu(path_shellCommand=str(sh_file), terminal="xterm")
+    with mock.patch("subprocess.call"):
+        menu.open_terminal("htop", hold=True)
+    contents = sh_file.read_text()
+    assert contents == ('#! /bin/bash\nhtop\necho "\n\nPress enter to exit";read var;')
+
+
+def test_open_terminal_chmods_file_0744(tmp_path):
+    sh_file = tmp_path / "shellCommand.sh"
+    menu = make_menu(path_shellCommand=str(sh_file), terminal="xterm")
+    with mock.patch("subprocess.call"), mock.patch("os.chmod") as chmod:
+        menu.open_terminal("htop")
+    chmod.assert_called_once_with(str(sh_file), 0o744)
+
+
+# ---------------------------------------------------------------------------
+# open_url()
+# ---------------------------------------------------------------------------
+
+
+def test_open_url_executes_webbrowser_with_url():
+    menu = make_menu(webbrowser="firefox", interactive_shell=False)
+    with mock.patch("subprocess.call") as call:
+        menu.open_url("http://example.com")
+    call.assert_called_once_with(["firefox", "http://example.com"])
+
+
+def test_open_url_percent_encodes_spaces():
+    # Spaces anywhere in the url (including the path) are turned into %20 before
+    # the command string is split, so they don't get split into extra argv items.
+    menu = make_menu(webbrowser="firefox", interactive_shell=False)
+    with mock.patch("subprocess.call") as call:
+        menu.open_url("http://example.com/a b")
+    call.assert_called_once_with(["firefox", "http://example.com/a%20b"])
+
+
+# ---------------------------------------------------------------------------
+# open_in_terminal_editor() - note: it uses the module-global `d`, not `self`.
+# ---------------------------------------------------------------------------
+
+
+def test_open_in_terminal_editor_missing_path_returns_none(tmp_path):
+    menu = make_menu()
+    missing = str(tmp_path / "does-not-exist.txt")
+    with mock.patch("subprocess.call") as call:
+        result = menu.open_in_terminal_editor(missing)
+    assert result is None
+    call.assert_not_called()
+
+
+def test_open_in_terminal_editor_builds_command_via_global_d(tmp_path):
+    real_file = tmp_path / "notes.txt"
+    real_file.write_text("hi")
+    editor_menu = make_menu(terminal="xterm", terminal_editor="vim")
+
+    # The method references the module global `d`, so patch that for both the
+    # prefs lookup and the execute() call it delegates to.
+    with (
+        mock.patch.object(main, "d", editor_menu),
+        mock.patch.object(editor_menu, "execute") as execute,
+    ):
+        execute.return_value = 0
+        rc = main.dmenu.open_in_terminal_editor(editor_menu, str(real_file))
+
+    # Command string: terminal -e 'editor path' with spaces in path escaped.
+    expected_cmd = "xterm -e 'vim %s'" % str(real_file)
+    execute.assert_called_once_with(expected_cmd, False)
+    assert rc == 0
+
+
+def test_open_in_terminal_editor_escapes_spaces_in_path(tmp_path):
+    spaced = tmp_path / "my notes.txt"
+    spaced.write_text("hi")
+    editor_menu = make_menu(terminal="xterm", terminal_editor="nano")
+    with (
+        mock.patch.object(main, "d", editor_menu),
+        mock.patch.object(editor_menu, "execute") as execute,
+    ):
+        main.dmenu.open_in_terminal_editor(editor_menu, str(spaced))
+    sent_cmd = execute.call_args[0][0]
+    # Spaces in the path are backslash-escaped inside the single-quoted command.
+    assert "my\\ notes.txt" in sent_cmd
+    assert sent_cmd.startswith("xterm -e 'nano ")
+
+
+# ---------------------------------------------------------------------------
+# handle_command() - the special modifier characters and dispatch logic.
+# ---------------------------------------------------------------------------
+
+
+def test_handle_command_at_suffix_opens_terminal_editor(tmp_path):
+    target = tmp_path / "file.txt"
+    target.write_text("x")
+    menu = make_menu()
+    with mock.patch.object(menu, "open_in_terminal_editor") as editor:
+        main.handle_command(menu, str(target) + "@")
+    # The trailing '@' is stripped before being passed to the editor.
+    editor.assert_called_once_with(str(target))
+
+
+def test_handle_command_single_semicolon_runs_in_terminal_no_hold():
+    menu = make_menu()
+    with (
+        mock.patch.object(menu, "open_terminal") as term,
+        mock.patch("os.path.isdir", return_value=False),
+    ):
+        main.handle_command(menu, "htop;")
+    term.assert_called_once_with("htop", hold=False)
+
+
+def test_handle_command_double_semicolon_runs_in_terminal_with_hold():
+    menu = make_menu()
+    with (
+        mock.patch.object(menu, "open_terminal") as term,
+        mock.patch("os.path.isdir", return_value=False),
+    ):
+        main.handle_command(menu, "htop;;")
+    term.assert_called_once_with("htop", hold=True)
+
+
+def test_handle_command_semicolon_on_directory_opens_terminal_directly():
+    menu = make_menu(terminal="xterm")
+    with (
+        mock.patch.object(menu, "open_terminal") as term,
+        mock.patch("os.path.isdir", return_value=True),
+    ):
+        main.handle_command(menu, "/some/dir;")
+    # A directory + ';' opens a terminal cd'd into it, with direct=True.
+    term.assert_called_once_with("cd /some/dir && xterm &", direct=True)
+
+
+def test_handle_command_http_url_dispatches_to_open_url():
+    menu = make_menu()
+    with mock.patch.object(menu, "open_url") as open_url:
+        main.handle_command(menu, "http://example.com")
+    open_url.assert_called_once_with("http://example.com")
+
+
+def test_handle_command_https_url_dispatches_to_open_url():
+    menu = make_menu()
+    with mock.patch.object(menu, "open_url") as open_url:
+        main.handle_command(menu, "https://example.com/path")
+    open_url.assert_called_once_with("https://example.com/path")
+
+
+def test_handle_command_executable_binary_path_is_executed():
+    menu = make_menu()
+    with (
+        mock.patch.object(menu, "execute") as execute,
+        mock.patch("dmenu_extended.main.is_binary", return_value=True),
+    ):
+        main.handle_command(menu, "/usr/bin/firefox")
+    execute.assert_called_once_with("/usr/bin/firefox")
+
+
+def test_handle_command_path_with_spaces_known_binary_is_executed():
+    menu = make_menu()
+    with (
+        mock.patch.object(menu, "execute") as execute,
+        mock.patch("dmenu_extended.main.is_binary", return_value=False),
+        mock.patch.object(menu, "scan_binaries", return_value=["xdg-open"]),
+    ):
+        main.handle_command(menu, "xdg-open /home/user/a/b")
+    execute.assert_called_once_with("xdg-open /home/user/a/b")
+
+
+def test_handle_command_path_with_spaces_unknown_binary_opens_directory():
+    menu = make_menu()
+    with contextlib.ExitStack() as stack:
+        stack.enter_context(
+            mock.patch("dmenu_extended.main.is_binary", return_value=False)
+        )
+        stack.enter_context(mock.patch.object(menu, "scan_binaries", return_value=[]))
+        stack.enter_context(mock.patch("os.path.isdir", return_value=True))
+        open_dir = stack.enter_context(mock.patch.object(menu, "open_directory"))
+        main.handle_command(menu, "/home/user/some dir")
+    open_dir.assert_called_once_with("/home/user/some dir")
+
+
+def test_handle_command_path_no_space_file_opens_file():
+    menu = make_menu()
+    with (
+        mock.patch("dmenu_extended.main.is_binary", return_value=False),
+        mock.patch("os.path.isdir", return_value=False),
+        mock.patch.object(menu, "open_file") as open_file,
+    ):
+        main.handle_command(menu, "/home/user/notes.txt")
+    open_file.assert_called_once_with("/home/user/notes.txt")
+
+
+def test_handle_command_path_no_space_directory_opens_directory():
+    menu = make_menu()
+    with (
+        mock.patch("dmenu_extended.main.is_binary", return_value=False),
+        mock.patch("os.path.isdir", return_value=True),
+        mock.patch.object(menu, "open_directory") as open_dir,
+    ):
+        main.handle_command(menu, "/home/user/Documents")
+    open_dir.assert_called_once_with("/home/user/Documents")
+
+
+def test_handle_command_plain_command_no_slash_is_executed():
+    menu = make_menu()
+    with mock.patch.object(menu, "execute") as execute:
+        main.handle_command(menu, "firefox")
+    execute.assert_called_once_with("firefox")
+
+
+def test_handle_command_tilde_is_expanded_before_dispatch():
+    menu = make_menu()
+    home = os.path.expanduser("~")
+    with (
+        mock.patch("dmenu_extended.main.is_binary", return_value=False),
+        mock.patch("os.path.isdir", return_value=False),
+        mock.patch.object(menu, "open_file") as open_file,
+    ):
+        main.handle_command(menu, "~/notes.txt")
+    open_file.assert_called_once_with(home + "/notes.txt")
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([__file__, "-q"]))

--- a/tests/test_helpers_extra.py
+++ b/tests/test_helpers_extra.py
@@ -1,0 +1,367 @@
+#!/usr/bin/env python3
+
+"""Characterisation tests for the remaining helper gaps in dmenu_extended.main.
+
+These pin down the CURRENT behaviour (including quirks) of:
+
+* cache_load() visibility/assembly branches not already covered by
+  tests/test_cache.py: show_plugins=False forcing cache_plugins to '',
+  show_recent=False forcing cache_frequent to '', the '-> Settings\\n' line
+  being stripped out of the plugins cache, and the prepend ordering of the
+  frequently-used items relative to the scanned items.
+* retrieve_aliased_command(): a real lookup returning item[1], None on a miss,
+  and the unconditional print(alias) side effect.
+* open_directory(): the filebrowser command string it hands to execute().
+* open_file()'s exit-code 256/4 fallback-offer path.
+* get_password(): the in-place prefs['password_helper'] {prompt} substitution
+  quirk, then the command_output delegation.
+
+The cache files are redirected into a temp dir via DMENU_EXTENDED_CACHE_DIR and
+the module is reloaded, mirroring tests/test_cache.py. Every boundary that would
+touch the real system (subprocess, the menu/select/message UI, the cache regen)
+is mocked so nothing real is launched and the real config is never touched.
+"""
+
+import contextlib
+import importlib
+import json
+import os
+import shutil
+import sys
+import tempfile
+import unittest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+
+from dmenu_extended import main
+import mock
+
+
+class HelpersTestBase(unittest.TestCase):
+    """Redirect cache files into a temp dir and give a fresh dmenu instance.
+
+    The module reads DMENU_EXTENDED_CACHE_DIR at import time to choose
+    path_cache, so we set it, reload the module, then re-point the module-level
+    file_cache_* globals (mirroring tests/test_cache.py).
+    """
+
+    def setUp(self):
+        self.test_dir = tempfile.mkdtemp()
+        self._orig_cache_dir = os.environ.get("DMENU_EXTENDED_CACHE_DIR")
+        os.environ["DMENU_EXTENDED_CACHE_DIR"] = self.test_dir
+
+        importlib.reload(main)
+        self._repoint_cache_globals()
+
+        self.dmenu = main.dmenu()
+        # Avoid sharing class-level prefs between instances/tests, and a fresh
+        # copy so the get_password in-place mutation cannot leak across tests.
+        self.dmenu.prefs = dict(main.default_prefs)
+        # load_preferences() becomes a no-op once prefs is truthy, but stub it
+        # so nothing reads the user's real config from disk.
+        self.dmenu.load_preferences = lambda: None
+
+    def tearDown(self):
+        if self._orig_cache_dir is not None:
+            os.environ["DMENU_EXTENDED_CACHE_DIR"] = self._orig_cache_dir
+        else:
+            os.environ.pop("DMENU_EXTENDED_CACHE_DIR", None)
+
+        importlib.reload(main)
+        shutil.rmtree(self.test_dir, ignore_errors=True)
+
+    def _repoint_cache_globals(self):
+        c = main.path_cache
+        main.file_cache = c + "/dmenuExtended_all.txt"
+        main.file_cache_binaries = c + "/dmenuExtended_binaries.txt"
+        main.file_cache_files = c + "/dmenuExtended_files.txt"
+        main.file_cache_folders = c + "/dmenuExtended_folders.txt"
+        main.file_cache_aliases = c + "/dmenuExtended_aliases.txt"
+        main.file_cache_aliasesLookup = c + "/dmenuExtended_aliases_lookup.json"
+        main.file_cache_plugins = c + "/dmenuExtended_plugins.txt"
+        main.file_cache_frequentlyUsed_frequency = (
+            c + "/dmenuExtended_frequentlyUsed_frequency.json"
+        )
+        main.file_cache_frequentlyUsed_ordered = (
+            c + "/dmenuExtended_frequentlyUsed_ordered.json"
+        )
+
+    def _write_frequent(self, lines):
+        """Write the ordered frequently-used cache that cache_load reads via
+        frequent_commands_retrieve()."""
+        with open(main.file_cache_frequentlyUsed_ordered, "w") as f:
+            f.write("".join(line + "\n" for line in lines))
+
+
+# ---------------------------------------------------------------------------
+# cache_load(): visibility and assembly branches (main.py:920-952)
+# ---------------------------------------------------------------------------
+
+
+class TestCacheLoadVisibility(HelpersTestBase):
+    def test_show_plugins_false_forces_plugins_empty(self):
+        # show_plugins False drops the plugins cache entirely (but Settings stay).
+        self.dmenu.cache_save(["a plugin entry"], main.file_cache_plugins)
+        self.dmenu.cache_save(["scanned item"], main.file_cache)
+        self.dmenu.show_plugins = False
+        text = self.dmenu.cache_load()
+        self.assertNotIn("a plugin entry", text)
+        self.assertIn("scanned item", text)
+        # The Settings entry is still injected even with plugins hidden.
+        self.assertIn("Settings", text)
+
+    def test_show_recent_false_forces_frequent_empty(self):
+        # show_recent False drops the frequently-used items even when the cache
+        # exists and frequently_used is non-zero.
+        self.dmenu.prefs["frequently_used"] = 5
+        self._write_frequent(["recent one", "recent two"])
+        self.dmenu.cache_save([], main.file_cache_plugins)
+        self.dmenu.cache_save(["scanned item"], main.file_cache)
+        self.dmenu.show_recent = False
+        text = self.dmenu.cache_load()
+        self.assertNotIn("recent one", text)
+        self.assertNotIn("recent two", text)
+        self.assertIn("scanned item", text)
+
+    def test_show_recent_true_includes_frequent_items(self):
+        # With show_recent left at its default True and a populated cache, the
+        # frequently-used items appear.
+        self.dmenu.prefs["frequently_used"] = 5
+        self._write_frequent(["recent one"])
+        self.dmenu.cache_save([], main.file_cache_plugins)
+        self.dmenu.cache_save(["scanned item"], main.file_cache)
+        text = self.dmenu.cache_load()
+        self.assertIn("recent one", text)
+
+    def test_settings_line_stripped_out_of_plugins_cache(self):
+        # The plugins cache may contain its own "-> Settings" line; cache_load
+        # removes that copy so it is not duplicated with the injected one.
+        settings_line = self.dmenu.prefs["indicator_submenu"] + " Settings"
+        self.dmenu.cache_save(
+            ["plugin one", settings_line, "plugin two"], main.file_cache_plugins
+        )
+        self.dmenu.cache_save(["scanned item"], main.file_cache)
+        text = self.dmenu.cache_load()
+        # The injected Settings entry appears exactly once, not twice.
+        self.assertEqual(text.count(settings_line), 1)
+        self.assertIn("plugin one", text)
+        self.assertIn("plugin two", text)
+
+    def test_assembly_ordering_plugins_settings_frequent_scanned(self):
+        # show_settings default True -> plugins, then Settings, then frequent,
+        # then scanned. Frequent items are prepended ahead of the scanned ones.
+        self.dmenu.prefs["frequently_used"] = 5
+        self._write_frequent(["FREQ_ITEM"])
+        self.dmenu.cache_save(["PLUGIN_ITEM"], main.file_cache_plugins)
+        self.dmenu.cache_save(["SCANNED_ITEM"], main.file_cache)
+        text = self.dmenu.cache_load()
+        settings_line = self.dmenu.prefs["indicator_submenu"] + " Settings"
+        # Positions must increase in this exact order.
+        self.assertLess(text.index("PLUGIN_ITEM"), text.index(settings_line))
+        self.assertLess(text.index(settings_line), text.index("FREQ_ITEM"))
+        self.assertLess(text.index("FREQ_ITEM"), text.index("SCANNED_ITEM"))
+
+    def test_show_settings_false_orders_plugins_frequent_scanned_settings(self):
+        # show_settings False -> plugins, frequent, scanned, then Settings last.
+        self.dmenu.prefs["frequently_used"] = 5
+        self._write_frequent(["FREQ_ITEM"])
+        self.dmenu.cache_save(["PLUGIN_ITEM"], main.file_cache_plugins)
+        self.dmenu.cache_save(["SCANNED_ITEM"], main.file_cache)
+        self.dmenu.show_settings = False
+        text = self.dmenu.cache_load()
+        settings_line = self.dmenu.prefs["indicator_submenu"] + " Settings"
+        self.assertLess(text.index("PLUGIN_ITEM"), text.index("FREQ_ITEM"))
+        self.assertLess(text.index("FREQ_ITEM"), text.index("SCANNED_ITEM"))
+        self.assertLess(text.index("SCANNED_ITEM"), text.index(settings_line))
+
+
+# ---------------------------------------------------------------------------
+# retrieve_aliased_command() (main.py:1051-1066)
+# ---------------------------------------------------------------------------
+
+
+class TestRetrieveAliasedCommand(HelpersTestBase):
+    def _write_lookup(self, pairs):
+        with open(main.file_cache_aliasesLookup, "w") as f:
+            json.dump(pairs, f)
+
+    def test_returns_command_for_matching_alias(self):
+        self._write_lookup([["Firefox", "firefox"], ["Htop", "htop;"]])
+        self.assertEqual(self.dmenu.retrieve_aliased_command("Htop"), "htop;")
+
+    def test_returns_none_on_miss(self):
+        # No matching first element -> the loop falls through and the method
+        # returns None implicitly.
+        self._write_lookup([["Firefox", "firefox"]])
+        self.assertIsNone(self.dmenu.retrieve_aliased_command("Nope"))
+
+    def test_prints_the_alias_unconditionally(self):
+        # The method prints the alias on every call regardless of hit/miss.
+        self._write_lookup([["Firefox", "firefox"]])
+        with mock.patch("builtins.print") as printed:
+            self.dmenu.retrieve_aliased_command("Firefox")
+        printed.assert_any_call("Firefox")
+
+
+# ---------------------------------------------------------------------------
+# open_directory() (main.py:661-666)
+# ---------------------------------------------------------------------------
+
+
+class TestOpenDirectory(HelpersTestBase):
+    def test_passes_quoted_path_to_filebrowser_via_execute(self):
+        self.dmenu.prefs["filebrowser"] = "thunar"
+        with mock.patch.object(self.dmenu, "execute") as execute:
+            self.dmenu.open_directory("/home/user/Documents")
+        # The path is double-quoted and appended after the filebrowser command.
+        execute.assert_called_once_with('thunar "/home/user/Documents"')
+
+
+# ---------------------------------------------------------------------------
+# open_file(): exit-code 256/4 fallback-offer path (main.py:722-748)
+# ---------------------------------------------------------------------------
+
+
+class TestOpenFileFallback(HelpersTestBase):
+    def test_zero_exit_code_takes_no_fallback(self):
+        # A successful open returns 0; none of the fallback logic runs.
+        self.dmenu.prefs["fileopener"] = "xdg-open"
+        with (
+            mock.patch.object(self.dmenu, "execute", return_value=0) as execute,
+            mock.patch.object(self.dmenu, "menu") as menu,
+        ):
+            self.dmenu.open_file("/tmp/notes.txt")
+        execute.assert_called_once_with('xdg-open "/tmp/notes.txt"', fork=False)
+        menu.assert_not_called()
+
+    def test_gnome_open_256_offers_xdg_open_and_retries_on_accept(self):
+        # gnome-open returning 256 offers xdg-open; accepting the offer switches
+        # the fileopener pref and recurses to retry the open.
+        self.dmenu.prefs["fileopener"] = "gnome-open"
+        offer = "Try opening with xdg-open?"
+        # First execute (gnome-open) fails with 256, the retried execute (now
+        # xdg-open) succeeds with 0.
+        with contextlib.ExitStack() as stack:
+            execute = stack.enter_context(
+                mock.patch.object(self.dmenu, "execute", side_effect=[256, 0])
+            )
+            stack.enter_context(
+                mock.patch.object(
+                    self.dmenu, "command_output", return_value=["text/plain"]
+                )
+            )
+            stack.enter_context(
+                mock.patch.object(self.dmenu, "menu", return_value=offer)
+            )
+            self.dmenu.open_file("/tmp/file.txt")
+        # The offer was accepted, so fileopener was switched to xdg-open and the
+        # second (recursive) execute used it.
+        self.assertEqual(self.dmenu.prefs["fileopener"], "xdg-open")
+        self.assertEqual(execute.call_count, 2)
+        execute.assert_any_call('xdg-open "/tmp/file.txt"', fork=False)
+
+    def test_gnome_open_256_offer_declined_does_not_switch_or_retry(self):
+        # Declining the menu offer leaves the fileopener untouched and does not
+        # retry the open.
+        self.dmenu.prefs["fileopener"] = "gnome-open"
+        with contextlib.ExitStack() as stack:
+            execute = stack.enter_context(
+                mock.patch.object(self.dmenu, "execute", return_value=256)
+            )
+            stack.enter_context(
+                mock.patch.object(
+                    self.dmenu, "command_output", return_value=["text/plain"]
+                )
+            )
+            stack.enter_context(
+                mock.patch.object(self.dmenu, "menu", return_value="something else")
+            )
+            self.dmenu.open_file("/tmp/file.txt")
+        self.assertEqual(self.dmenu.prefs["fileopener"], "gnome-open")
+        execute.assert_called_once()
+
+    def test_xdg_open_4_shows_message_with_no_offer_option(self):
+        # xdg-open returning 4 marks an open_failure but leaves offer None, so
+        # the message list never gains an offer option; a NameError can surface
+        # if a previous loop left `option` bound, but with a single failure the
+        # menu is still called with the constructed message.
+        self.dmenu.prefs["fileopener"] = "xdg-open"
+        with contextlib.ExitStack() as stack:
+            stack.enter_context(
+                mock.patch.object(self.dmenu, "execute", return_value=4)
+            )
+            stack.enter_context(
+                mock.patch.object(
+                    self.dmenu, "command_output", return_value=["application/pdf"]
+                )
+            )
+            menu = stack.enter_context(mock.patch.object(self.dmenu, "menu"))
+            # offer is None so `option` is never assigned; message.append(option)
+            # raises NameError on a fresh interpreter state.
+            with self.assertRaises(NameError):
+                self.dmenu.open_file("/tmp/file.pdf")
+        menu.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# get_password() (main.py:537-546)
+# ---------------------------------------------------------------------------
+
+
+class TestGetPassword(HelpersTestBase):
+    def test_substitutes_prompt_in_place_and_delegates_to_command_output(self):
+        # password_helper items containing {prompt} are formatted in place, then
+        # the whole command list is handed to command_output.
+        self.dmenu.prefs["password_helper"] = [
+            "zenity",
+            "--password",
+            "--title={prompt}",
+        ]
+        with mock.patch.object(
+            self.dmenu, "command_output", return_value="hunter2"
+        ) as command_output:
+            result = self.dmenu.get_password()
+        self.assertEqual(result, "hunter2")
+        # Default prompt with no helper text is "Password: ".
+        command_output.assert_called_once_with(
+            ["zenity", "--password", "--title=Password: "]
+        )
+
+    def test_helper_text_is_embedded_in_the_prompt(self):
+        self.dmenu.prefs["password_helper"] = ["pinentry", "--prompt={prompt}"]
+        with mock.patch.object(
+            self.dmenu, "command_output", return_value=""
+        ) as command_output:
+            self.dmenu.get_password(helper_text="sudo")
+        # helper_text is wrapped in parentheses inside the prompt string.
+        command_output.assert_called_once_with(
+            ["pinentry", "--prompt=Password (sudo): "]
+        )
+
+    def test_substitution_mutates_the_prefs_list_in_place(self):
+        # The method takes a reference to prefs['password_helper'] (not a copy)
+        # and rewrites the {prompt} element in place, so the stored pref is
+        # mutated as a side effect.
+        helper = ["zenity", "--title={prompt}"]
+        self.dmenu.prefs["password_helper"] = helper
+        with mock.patch.object(self.dmenu, "command_output", return_value=""):
+            self.dmenu.get_password()
+        self.assertEqual(
+            self.dmenu.prefs["password_helper"],
+            ["zenity", "--title=Password: "],
+        )
+        # Same list object, confirming the in-place mutation quirk.
+        self.assertIs(self.dmenu.prefs["password_helper"], helper)
+
+    def test_items_without_prompt_token_are_left_unchanged(self):
+        self.dmenu.prefs["password_helper"] = ["zenity", "--password"]
+        with mock.patch.object(
+            self.dmenu, "command_output", return_value="pw"
+        ) as command_output:
+            self.dmenu.get_password()
+        # No {prompt} token anywhere, so the command list is passed through as-is.
+        command_output.assert_called_once_with(["zenity", "--password"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_launch.py
+++ b/tests/test_launch.py
@@ -1,0 +1,427 @@
+#!/usr/bin/env python3
+
+"""Characterisation tests for the launch entry points.
+
+Pins the current behaviour of ``init_menu(launch_args)`` and ``run()`` in
+``dmenu_extended.main``: argument parsing, the ``show_*`` toggles, the
+executable check via ``shutil.which``, and the automation/bypass path where
+launch arguments drive menu selections through to the command handler.
+
+These assert the ACTUAL behaviour today, including quirks (e.g. ``init_menu``
+returns ``1`` on ``--help`` and ``None`` otherwise, and mutates module-level
+state). Boundaries (subprocess, preferences, plugins, the command handler) are
+mocked so no real menu launches and nothing touches the real config.
+
+The project targets Python 3.8, so contextlib.ExitStack is used instead of
+parenthesised ``with`` blocks (which are 3.9+ syntax).
+"""
+
+import contextlib
+import os
+import sys
+
+import mock
+import pytest
+
+# Add src directory to path to import dmenu_extended
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+
+from dmenu_extended import main
+
+
+def patches(*context_managers):
+    """Enter several mock patchers under one ExitStack and yield their mocks."""
+
+    stack = contextlib.ExitStack()
+    mocks = [stack.enter_context(cm) for cm in context_managers]
+    return stack, mocks
+
+
+@pytest.fixture(autouse=True)
+def restore_module_state():
+    """Save and restore the global state that init_menu/run mutate.
+
+    ``init_menu`` flips ``main.debug`` and the ``main.d.show_*`` toggles and
+    overwrites ``main.d.launch_args``/``main.d.prefs``. Without restoring these
+    between tests the suite would leak state across cases.
+    """
+
+    saved_debug = main.debug
+    saved_prefs = main.d.prefs
+    saved_launch_args = main.d.launch_args
+    saved_show = (
+        main.d.show_scanned,
+        main.d.show_recent,
+        main.d.show_settings,
+        main.d.show_plugins,
+    )
+
+    yield
+
+    main.debug = saved_debug
+    main.d.prefs = saved_prefs
+    main.d.launch_args = saved_launch_args
+    (
+        main.d.show_scanned,
+        main.d.show_recent,
+        main.d.show_settings,
+        main.d.show_plugins,
+    ) = saved_show
+
+
+@pytest.fixture
+def prefs():
+    """A fresh copy of the default preferences installed on the shared instance.
+
+    ``load_preferences`` is patched out in the tests that use this so the copy
+    here is exactly what the code under test sees.
+    """
+
+    main.d.prefs = dict(main.default_prefs)
+    return main.d.prefs
+
+
+# ---------------------------------------------------------------------------
+# init_menu: --help
+# ---------------------------------------------------------------------------
+
+
+def test_init_menu_help_returns_1_and_prints(capsys):
+    # --help short-circuits everything: returns 1 (truthy), prints the Help
+    # text, and never reaches load_preferences or the executable check.
+    stack, (load_prefs, which) = patches(
+        mock.patch.object(main.d, "load_preferences"),
+        mock.patch("shutil.which"),
+    )
+    with stack:
+        result = main.init_menu(["--help"])
+
+    assert result == 1
+    assert "Dmenu Extended command line options" in capsys.readouterr().out
+    load_prefs.assert_not_called()
+    which.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# init_menu: executable check
+# ---------------------------------------------------------------------------
+
+
+def test_init_menu_missing_executable_returns_1(prefs, capsys):
+    # When shutil.which reports the configured menu binary is absent, init_menu
+    # prints an abort message and returns 1.
+    stack, (_load_prefs, which) = patches(
+        mock.patch.object(main.d, "load_preferences"),
+        mock.patch("shutil.which", return_value=None),
+    )
+    with stack:
+        result = main.init_menu([])
+
+    assert result == 1
+    which.assert_called_once_with(prefs["menu"])
+    assert "executable not found, aborting" in capsys.readouterr().out
+
+
+def test_init_menu_present_executable_returns_none(prefs):
+    # The happy path returns None (falsy), having loaded preferences and checked
+    # the configured menu against shutil.which.
+    stack, (load_prefs, which) = patches(
+        mock.patch.object(main.d, "load_preferences"),
+        mock.patch("shutil.which", return_value="/usr/bin/dmenu"),
+    )
+    with stack:
+        result = main.init_menu([])
+
+    assert result is None
+    load_prefs.assert_called_once()
+    which.assert_called_once_with(prefs["menu"])
+
+
+# ---------------------------------------------------------------------------
+# init_menu: flag parsing and state mutation
+# ---------------------------------------------------------------------------
+
+
+def test_init_menu_no_recent_flag(prefs):
+    # --no-recent clears show_recent, leaves the other toggles untrue, and is
+    # consumed from the argument list (removed in place).
+    main.d.show_recent = True
+    args = ["--no-recent"]
+    stack, _ = patches(
+        mock.patch.object(main.d, "load_preferences"),
+        mock.patch("shutil.which", return_value="/usr/bin/dmenu"),
+    )
+    with stack:
+        main.init_menu(args)
+
+    assert main.d.show_recent is False
+    assert args == []
+    assert main.d.launch_args == []
+
+
+def test_init_menu_all_visibility_flags_removed_and_args_become_launch_args(prefs):
+    # All four visibility flags flip their respective toggles to False, are
+    # stripped from the list, and whatever non-flag tokens remain become the
+    # menu's launch_args (the automation queue).
+    main.d.show_scanned = True
+    main.d.show_recent = True
+    main.d.show_settings = True
+    main.d.show_plugins = True
+
+    args = [
+        "--no-scanned",
+        "--no-recent",
+        "--no-settings",
+        "--no-plugins",
+        "selection one",
+        "selection two",
+    ]
+    stack, _ = patches(
+        mock.patch.object(main.d, "load_preferences"),
+        mock.patch("shutil.which", return_value="/usr/bin/dmenu"),
+    )
+    with stack:
+        main.init_menu(args)
+
+    assert main.d.show_scanned is False
+    assert main.d.show_recent is False
+    assert main.d.show_settings is False
+    assert main.d.show_plugins is False
+    # Flags consumed, only the menu selections remain.
+    assert args == ["selection one", "selection two"]
+    assert main.d.launch_args == ["selection one", "selection two"]
+
+
+def test_init_menu_debug_flag_sets_global_and_is_removed(prefs, capsys):
+    # --debug sets the module-level debug flag, prints two debug lines, and is
+    # removed from the argument list (the remaining tokens still flow through).
+    main.debug = False
+    args = ["--debug", "thing"]
+    stack, _ = patches(
+        mock.patch.object(main.d, "load_preferences"),
+        mock.patch("shutil.which", return_value="/usr/bin/dmenu"),
+    )
+    with stack:
+        main.init_menu(args)
+
+    assert main.debug is True
+    assert args == ["thing"]
+    assert main.d.launch_args == ["thing"]
+    out = capsys.readouterr().out
+    assert "Debugging enabled" in out
+    assert "Launch arguments: ['thing']" in out
+
+
+def test_init_menu_unknown_arg_passed_through_as_launch_arg(prefs):
+    # A token that is not a recognised flag is treated as a menu selection and
+    # ends up in launch_args verbatim (no error, no removal).
+    args = ["--no-such-flag"]
+    stack, _ = patches(
+        mock.patch.object(main.d, "load_preferences"),
+        mock.patch("shutil.which", return_value="/usr/bin/dmenu"),
+    )
+    with stack:
+        main.init_menu(args)
+
+    assert main.d.launch_args == ["--no-such-flag"]
+
+
+# ---------------------------------------------------------------------------
+# dmenu.menu / dmenu.select: launch-argument bypass
+# ---------------------------------------------------------------------------
+
+
+def test_select_bypassed_returns_matching_item(prefs):
+    # select() with a queued launch arg matches it against the items list and
+    # returns the matching item (the queued value is consumed).
+    main.d.launch_args = ["htop"]
+    result = main.d.select(["firefox", "htop", "code"])
+
+    assert result == "htop"
+    assert main.d.launch_args == []
+
+
+def test_select_bypassed_numeric_returns_index(prefs):
+    # numeric=True makes select() return the index of the matched item rather
+    # than the item itself.
+    main.d.launch_args = ["htop"]
+    result = main.d.select(["firefox", "htop", "code"], numeric=True)
+
+    assert result == 1
+
+
+def test_select_no_match_returns_minus_one(prefs):
+    # When the queued launch arg matches none of the items, select() returns -1.
+    main.d.launch_args = ["nonexistent"]
+    result = main.d.select(["firefox", "htop"])
+
+    assert result == -1
+
+
+# ---------------------------------------------------------------------------
+# run(): control flow
+# ---------------------------------------------------------------------------
+
+
+def test_run_returns_early_when_init_menu_truthy():
+    # run() bails out (returning None) without loading the cache whenever
+    # init_menu returns a truthy value (e.g. --help or a missing executable).
+    stack, (_init, cache_load) = patches(
+        mock.patch.object(main, "init_menu", return_value=1),
+        mock.patch.object(main.d, "cache_load"),
+    )
+    with stack:
+        result = main.run()
+
+    assert result is None
+    cache_load.assert_not_called()
+
+
+def test_run_empty_selection_does_nothing(prefs):
+    # If the first menu returns an empty/whitespace-only string, run() takes no
+    # further action: no plugins are loaded and no command is handled.
+    main.d.launch_args = []
+    stack, (_init, _cache, _menu, load_plugins, handle_command) = patches(
+        mock.patch.object(main, "init_menu", return_value=None),
+        mock.patch.object(main.d, "cache_load", return_value="a\nb"),
+        mock.patch.object(main.d, "menu", return_value="   "),
+        mock.patch.object(main, "load_plugins"),
+        mock.patch.object(main, "handle_command"),
+    )
+    with stack:
+        main.run()
+
+    load_plugins.assert_not_called()
+    handle_command.assert_not_called()
+
+
+def test_run_automation_routes_launch_arg_to_handle_command(prefs):
+    # End-to-end automation: a queued launch arg drives the first menu, and a
+    # plain command (no slash, colon, URL prefix, or special keyword) is routed
+    # to handle_command with the selected text. The launch queue is drained.
+    prefs["frequently_used"] = 0
+    main.d.launch_args = ["htop"]
+    stack, (_init, _cache, _plugins, _alias, handle_command) = patches(
+        mock.patch.object(main, "init_menu", return_value=None),
+        mock.patch.object(main.d, "cache_load", return_value="firefox\nhtop"),
+        mock.patch.object(main, "load_plugins", return_value=[]),
+        mock.patch.object(main.d, "retrieve_aliased_command", return_value=None),
+        mock.patch.object(main, "handle_command"),
+    )
+    with stack:
+        main.run()
+
+    handle_command.assert_called_once_with(main.d, "htop")
+    assert main.d.launch_args == []
+
+
+def test_run_stores_frequent_command_before_handling(prefs):
+    # When frequently_used > 0 and the selection is a non-aliased command, run()
+    # records the selection via frequent_commands_store before handling it.
+    prefs["frequently_used"] = 5
+    main.d.launch_args = []
+    stack, (_init, _cache, _menu, _plugins, _alias, store, handle_command) = patches(
+        mock.patch.object(main, "init_menu", return_value=None),
+        mock.patch.object(main.d, "cache_load", return_value="x"),
+        mock.patch.object(main.d, "menu", return_value="firefox"),
+        mock.patch.object(main, "load_plugins", return_value=[]),
+        mock.patch.object(main.d, "retrieve_aliased_command", return_value=None),
+        mock.patch.object(main, "frequent_commands_store"),
+        mock.patch.object(main, "handle_command"),
+    )
+    with stack:
+        main.run()
+
+    store.assert_called_once_with("firefox")
+    handle_command.assert_called_once_with(main.d, "firefox")
+
+
+def test_run_aliased_command_stored_as_display_text_and_dealiased(prefs):
+    # For an aliased selection: the displayed alias text is what gets recorded
+    # in the frequent store, but the resolved (de-aliased) command is what is
+    # passed to handle_command.
+    prefs["frequently_used"] = 1
+    main.d.launch_args = []
+    stack, (_init, _cache, _menu, _plugins, _alias, store, handle_command) = patches(
+        mock.patch.object(main, "init_menu", return_value=None),
+        mock.patch.object(main.d, "cache_load", return_value="x"),
+        mock.patch.object(main.d, "menu", return_value="My Alias"),
+        mock.patch.object(main, "load_plugins", return_value=[]),
+        mock.patch.object(
+            main.d, "retrieve_aliased_command", return_value="firefox --private"
+        ),
+        mock.patch.object(main, "frequent_commands_store"),
+        mock.patch.object(main, "handle_command"),
+    )
+    with stack:
+        main.run()
+
+    store.assert_called_once_with("My Alias")
+    handle_command.assert_called_once_with(main.d, "firefox --private")
+
+
+def test_run_rebuild_cache_keyword_regenerates(prefs):
+    # The literal selection "rebuild cache" triggers cache_regenerate rather
+    # than handle_command, and (on success, result truthy) shows a follow-up
+    # menu message.
+    prefs["frequently_used"] = 0
+    main.d.launch_args = []
+    stack, (_init, _cache, menu, _plugins, _alias, regenerate, handle_command) = (
+        patches(
+            mock.patch.object(main, "init_menu", return_value=None),
+            mock.patch.object(main.d, "cache_load", return_value="x"),
+            mock.patch.object(main.d, "menu", return_value="rebuild cache"),
+            mock.patch.object(main, "load_plugins", return_value=[]),
+            mock.patch.object(main.d, "retrieve_aliased_command", return_value=None),
+            mock.patch.object(main.d, "cache_regenerate", return_value=1),
+            mock.patch.object(main, "handle_command"),
+        )
+    )
+    with stack:
+        main.run()
+
+    regenerate.assert_called_once()
+    handle_command.assert_not_called()
+    # First menu call selects, second reports the result.
+    assert menu.call_count == 2
+
+
+def test_run_plugin_hook_invoked_when_title_matches(prefs):
+    # When the selection begins with a plugin's title, run() loads that plugin's
+    # preferences and calls its run() with the remainder of the selection
+    # (stripped of the title), bypassing handle_command entirely.
+    prefs["frequently_used"] = 0
+    main.d.launch_args = []
+
+    class FakePlugin:
+        is_submenu = False
+        title = "MyPlugin"
+
+        def __init__(self):
+            self.loaded = False
+            self.ran_with = None
+
+        def load_preferences(self):
+            self.loaded = True
+
+        def run(self, argument):
+            self.ran_with = argument
+
+    plugin = FakePlugin()
+    stack, (_init, _cache, _menu, _plugins, handle_command) = patches(
+        mock.patch.object(main, "init_menu", return_value=None),
+        mock.patch.object(main.d, "cache_load", return_value="x"),
+        mock.patch.object(main.d, "menu", return_value="MyPlugin hello"),
+        mock.patch.object(main, "load_plugins", return_value=[{"plugin": plugin}]),
+        mock.patch.object(main, "handle_command"),
+    )
+    with stack:
+        main.run()
+
+    assert plugin.loaded is True
+    assert plugin.ran_with == "hello"
+    handle_command.assert_not_called()
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([__file__, "-q"]))

--- a/tests/test_menu.py
+++ b/tests/test_menu.py
@@ -1,0 +1,365 @@
+#! /usr/bin/env python3
+
+"""Characterisation tests for menu I/O.
+
+Pins down the CURRENT behaviour of dmenu.menu(), select(), message_open(),
+message_close() and the interactive_shell branch of execute(). These methods
+shell out to the configured menu (dmenu/rofi) via subprocess. Popen is mocked
+so nothing real is launched and we can assert on the argv that was built.
+"""
+
+import sys
+from os import path
+
+import mock
+import pytest
+
+# Add src directory to path to import dmenu_extended
+sys.path.insert(0, path.join(path.dirname(__file__), "..", "src"))
+import dmenu_extended as d
+
+
+def make_menu(prefs=None):
+    """Return a dmenu instance with prefs pre-loaded so load_preferences()
+    becomes a no-op, and an empty per-instance launch_args list.
+    """
+    menu = d.dmenu()
+    if prefs is None:
+        prefs = {
+            "menu": "dmenu",
+            "menu_arguments": ["-b", "-i"],
+        }
+    menu.prefs = prefs
+    # load_preferences() is a no-op once prefs is truthy, but stub it anyway so
+    # the tests never depend on a real config file on disk.
+    menu.load_preferences = lambda: None
+    # launch_args defaults to a shared class-level list - give each instance
+    # its own so tests do not bleed into one another.
+    menu.launch_args = []
+    return menu
+
+
+def fake_popen(stdout="result\n", returncode=0):
+    """Build a mock standing in for subprocess.Popen.
+
+    communicate() returns (stdout, None) and the instance exposes returncode.
+    """
+    proc = mock.Mock()
+    proc.communicate.return_value = (stdout, None)
+    proc.returncode = returncode
+    proc.stdin = mock.Mock()
+    proc.pid = 4242
+    factory = mock.Mock(return_value=proc)
+    return factory, proc
+
+
+# ---------------------------------------------------------------------------
+# menu()
+# ---------------------------------------------------------------------------
+
+
+def test_menu_builds_argv_with_menu_name_args_and_prompt():
+    menu = make_menu({"menu": "dmenu", "menu_arguments": ["-b", "-i"]})
+    factory, proc = fake_popen(stdout="firefox\n")
+    with mock.patch("subprocess.Popen", factory):
+        out = menu.menu(["firefox", "chrome"], prompt="Open:")
+    assert out == "firefox"
+    argv = factory.call_args[0][0]
+    # menu name first, then the (expanded) arguments, then -p and the prompt.
+    assert argv == ["dmenu", "-b", "-i", "-p", "Open:"]
+
+
+def test_menu_empty_prompt_still_appends_dash_p_and_empty_string():
+    menu = make_menu({"menu": "dmenu", "menu_arguments": []})
+    factory, proc = fake_popen(stdout="x\n")
+    with mock.patch("subprocess.Popen", factory):
+        menu.menu(["x"])
+    argv = factory.call_args[0][0]
+    # The default prompt is "" but -p is always appended with the empty value.
+    assert argv == ["dmenu", "-p", ""]
+
+
+def test_menu_joins_list_items_with_newlines_into_communicate():
+    menu = make_menu()
+    factory, proc = fake_popen(stdout="a\n")
+    with mock.patch("subprocess.Popen", factory):
+        menu.menu(["a", "b", "c"], prompt="p")
+    # The list is joined with newlines and handed to communicate() as stdin.
+    proc.communicate.assert_called_once_with("a\nb\nc")
+
+
+def test_menu_passes_string_items_through_unchanged():
+    menu = make_menu()
+    factory, proc = fake_popen(stdout="a\n")
+    with mock.patch("subprocess.Popen", factory):
+        menu.menu("already a string", prompt="p")
+    proc.communicate.assert_called_once_with("already a string")
+
+
+def test_menu_strips_newlines_and_surrounding_whitespace_from_output():
+    menu = make_menu()
+    factory, proc = fake_popen(stdout="  spaced result  \n")
+    with mock.patch("subprocess.Popen", factory):
+        out = menu.menu(["spaced result"], prompt="p")
+    # Output is stripped of trailing newline then of surrounding whitespace.
+    assert out == "spaced result"
+
+
+def test_menu_empty_output_exits():
+    menu = make_menu()
+    factory, proc = fake_popen(stdout="\n")
+    with mock.patch("subprocess.Popen", factory):
+        with pytest.raises(SystemExit):
+            menu.menu(["a"], prompt="p")
+
+
+def test_menu_whitespace_only_output_exits():
+    menu = make_menu()
+    factory, proc = fake_popen(stdout="   \n")
+    with mock.patch("subprocess.Popen", factory):
+        with pytest.raises(SystemExit):
+            menu.menu(["a"], prompt="p")
+
+
+def test_menu_expands_environment_variables_in_arguments(monkeypatch):
+    monkeypatch.setenv("DMENU_TEST_COLOUR", "#abcdef")
+    menu = make_menu(
+        {"menu": "dmenu", "menu_arguments": ["-nf", "$DMENU_TEST_COLOUR", "-i"]}
+    )
+    factory, proc = fake_popen(stdout="x\n")
+    with mock.patch("subprocess.Popen", factory):
+        menu.menu(["x"], prompt="p")
+    argv = factory.call_args[0][0]
+    # $DMENU_TEST_COLOUR is expanded by os.path.expandvars before launch.
+    assert argv == ["dmenu", "-nf", "#abcdef", "-i", "-p", "p"]
+
+
+def test_menu_unset_variable_is_left_verbatim(monkeypatch):
+    monkeypatch.delenv("DMENU_DEFINITELY_UNSET", raising=False)
+    menu = make_menu({"menu": "dmenu", "menu_arguments": ["$DMENU_DEFINITELY_UNSET"]})
+    factory, proc = fake_popen(stdout="x\n")
+    with mock.patch("subprocess.Popen", factory):
+        menu.menu(["x"], prompt="p")
+    argv = factory.call_args[0][0]
+    # expandvars leaves an undefined variable untouched, so it is passed as-is.
+    assert argv == ["dmenu", "$DMENU_DEFINITELY_UNSET", "-p", "p"]
+
+
+def test_menu_uses_configured_menu_executable():
+    menu = make_menu({"menu": "rofi", "menu_arguments": ["-dmenu"]})
+    factory, proc = fake_popen(stdout="x\n")
+    with mock.patch("subprocess.Popen", factory):
+        menu.menu(["x"], prompt="p")
+    argv = factory.call_args[0][0]
+    assert argv[0] == "rofi"
+
+
+def test_menu_rofi_with_empty_items_substitutes_single_space():
+    menu = make_menu({"menu": "rofi", "menu_arguments": []})
+    factory, proc = fake_popen(stdout="x\n")
+    with mock.patch("subprocess.Popen", factory):
+        menu.menu([], prompt="p")
+    # rofi closes immediately on empty input, so a single space is sent instead.
+    proc.communicate.assert_called_once_with(" ")
+
+
+def test_menu_dmenu_with_empty_items_sends_empty_string():
+    menu = make_menu({"menu": "dmenu", "menu_arguments": []})
+    factory, proc = fake_popen(stdout="x\n")
+    with mock.patch("subprocess.Popen", factory):
+        menu.menu([], prompt="p")
+    # The space substitution is rofi-only; dmenu receives an empty string.
+    proc.communicate.assert_called_once_with("")
+
+
+def test_menu_returncode_10_with_output_copies_to_clipboard_and_exits():
+    menu = make_menu()
+    factory, proc = fake_popen(stdout="copy me\n", returncode=10)
+    with mock.patch("subprocess.Popen", factory):
+        with mock.patch.object(menu, "copy_to_clipboard") as clip:
+            with pytest.raises(SystemExit):
+                menu.menu(["copy me"], prompt="p")
+    # rofi custom-key exit code 10 copies the selection then exits.
+    clip.assert_called_once_with("copy me")
+
+
+def test_menu_returncode_10_with_empty_output_exits_without_copy():
+    menu = make_menu()
+    factory, proc = fake_popen(stdout="\n", returncode=10)
+    with mock.patch("subprocess.Popen", factory):
+        with mock.patch.object(menu, "copy_to_clipboard") as clip:
+            with pytest.raises(SystemExit):
+                menu.menu(["a"], prompt="p")
+    clip.assert_not_called()
+
+
+def test_menu_launch_arg_bypasses_subprocess():
+    menu = make_menu()
+    menu.launch_args = ["preselected", "second"]
+    factory, proc = fake_popen()
+    with mock.patch("subprocess.Popen", factory):
+        out = menu.menu(["ignored"], prompt="p")
+    # The first launch_arg short-circuits the menu; Popen is never called.
+    assert out == "preselected"
+    factory.assert_not_called()
+    # The consumed arg is removed, leaving the remainder.
+    assert menu.launch_args == ["second"]
+
+
+# ---------------------------------------------------------------------------
+# select()
+# ---------------------------------------------------------------------------
+
+
+def test_select_returns_matching_item():
+    menu = make_menu()
+    items = ["alpha", "beta", "gamma"]
+    with mock.patch.object(menu, "menu", return_value="beta"):
+        assert menu.select(items, prompt="p") == "beta"
+
+
+def test_select_numeric_returns_index():
+    menu = make_menu()
+    items = ["alpha", "beta", "gamma"]
+    with mock.patch.object(menu, "menu", return_value="gamma"):
+        assert menu.select(items, prompt="p", numeric=True) == 2
+
+
+def test_select_returns_minus_one_when_no_match():
+    menu = make_menu()
+    items = ["alpha", "beta"]
+    with mock.patch.object(menu, "menu", return_value="zzz"):
+        assert menu.select(items, prompt="p") == -1
+
+
+def test_select_matches_on_substring_returning_first_item_found():
+    menu = make_menu()
+    items = ["one", "two", "three"]
+    # "two" is a substring of the menu result, and items are scanned in order;
+    # the first item whose text appears in the result wins.
+    with mock.patch.object(menu, "menu", return_value="two selected"):
+        assert menu.select(items, prompt="p") == "two"
+
+
+def test_select_launch_arg_bypasses_menu_call():
+    menu = make_menu()
+    menu.launch_args = ["beta", "next"]
+    items = ["alpha", "beta", "gamma"]
+    with mock.patch.object(menu, "menu") as inner:
+        result = menu.select(items, prompt="p")
+    # select() consumes its own launch_arg and never calls menu().
+    assert result == "beta"
+    inner.assert_not_called()
+    assert menu.launch_args == ["next"]
+
+
+# ---------------------------------------------------------------------------
+# message_open() / message_close()
+# ---------------------------------------------------------------------------
+
+
+def test_message_open_builds_argv_without_prompt():
+    menu = make_menu({"menu": "dmenu", "menu_arguments": ["-b", "-i"]})
+    factory, proc = fake_popen()
+    with mock.patch("subprocess.Popen", factory):
+        with mock.patch("os.setsid"):
+            menu.message_open("hello")
+    argv = factory.call_args[0][0]
+    # Unlike menu(), message_open() does not append a -p prompt.
+    assert argv == ["dmenu", "-b", "-i"]
+
+
+def test_message_open_expands_environment_variables(monkeypatch):
+    monkeypatch.setenv("DMENU_MSG_FONT", "terminus-12")
+    menu = make_menu({"menu": "dmenu", "menu_arguments": ["-fn", "$DMENU_MSG_FONT"]})
+    factory, proc = fake_popen()
+    with mock.patch("subprocess.Popen", factory):
+        with mock.patch("os.setsid"):
+            menu.message_open("hi")
+    argv = factory.call_args[0][0]
+    assert argv == ["dmenu", "-fn", "terminus-12"]
+
+
+def test_message_open_prefixes_please_wait_and_closes_stdin():
+    menu = make_menu({"menu": "dmenu", "menu_arguments": []})
+    factory, proc = fake_popen()
+    with mock.patch("subprocess.Popen", factory):
+        with mock.patch("os.setsid"):
+            menu.message_open("building cache")
+    # The message is coerced to str and prefixed with "Please wait: ".
+    proc.stdin.write.assert_called_once_with("Please wait: building cache")
+    proc.stdin.close.assert_called_once_with()
+
+
+def test_message_open_coerces_non_string_message():
+    menu = make_menu({"menu": "dmenu", "menu_arguments": []})
+    factory, proc = fake_popen()
+    with mock.patch("subprocess.Popen", factory):
+        with mock.patch("os.setsid"):
+            menu.message_open(12345)
+    proc.stdin.write.assert_called_once_with("Please wait: 12345")
+
+
+def test_message_open_stores_process_for_later_close():
+    menu = make_menu({"menu": "dmenu", "menu_arguments": []})
+    factory, proc = fake_popen()
+    with mock.patch("subprocess.Popen", factory):
+        with mock.patch("os.setsid"):
+            menu.message_open("x")
+    # The Popen handle is stashed on self.message so message_close() can kill it.
+    assert menu.message is proc
+
+
+def test_message_close_kills_process_group_when_message_present():
+    menu = make_menu({"menu": "dmenu", "menu_arguments": []})
+    factory, proc = fake_popen()
+    with mock.patch("subprocess.Popen", factory):
+        with mock.patch("os.setsid"):
+            menu.message_open("x")
+    with mock.patch("os.killpg") as killpg:
+        menu.message_close()
+    killpg.assert_called_once_with(proc.pid, d.signal.SIGTERM)
+
+
+def test_message_close_is_a_noop_when_no_message_was_opened():
+    menu = make_menu()
+    # Fresh instance has never opened a message, so message_close() must not
+    # attempt to kill anything.
+    assert not hasattr(menu, "message")
+    with mock.patch("os.killpg") as killpg:
+        menu.message_close()
+    killpg.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# execute() - interactive_shell branch (menu-adjacent config behaviour)
+# ---------------------------------------------------------------------------
+
+
+def test_execute_interactive_shell_runs_command_via_login_shell(monkeypatch):
+    monkeypatch.setenv("SHELL", "/bin/zsh")
+    menu = make_menu({"interactive_shell": True})
+    with mock.patch("subprocess.call", return_value=0) as call:
+        menu.execute("firefox --new-window")
+    # interactive_shell wraps the command in `$SHELL -i -c "<joined command>"`.
+    call.assert_called_once_with(["/bin/zsh", "-i", "-c", "firefox --new-window"])
+
+
+def test_execute_interactive_shell_falls_back_to_sh_when_shell_unset(monkeypatch):
+    monkeypatch.delenv("SHELL", raising=False)
+    menu = make_menu({"interactive_shell": True})
+    with mock.patch("subprocess.call", return_value=0) as call:
+        menu.execute("htop")
+    call.assert_called_once_with(["/bin/sh", "-i", "-c", "htop"])
+
+
+def test_execute_non_interactive_shell_calls_command_list_directly():
+    menu = make_menu({"interactive_shell": False})
+    with mock.patch("subprocess.call", return_value=0) as call:
+        menu.execute("firefox --new-window")
+    # Without interactive_shell the command list is passed straight to call().
+    call.assert_called_once_with(["firefox", "--new-window"])
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([__file__, "-q"]))

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -1,0 +1,733 @@
+#!/usr/bin/env python3
+
+"""Characterisation tests for the dmenu-extended plugin system.
+
+These tests pin down the CURRENT actual behaviour of the plugin machinery:
+the Version comparison class, the requirements/dependency logic, plugin
+loading, and the download/update flows. Where the code behaves oddly (for
+example raising on a plugin index entry that lacks a requirements key), the
+test asserts the odd behaviour rather than the ideal one.
+
+All boundaries are mocked: no real dmenu/rofi is launched, no network request
+is made (download_text / download_json / urllib are stubbed), and any
+filesystem writes go to tmp_path or a tempfile directory.
+"""
+
+import contextlib
+import os
+import sys
+import tempfile
+import types
+from os import path
+
+import mock
+
+# Add src directory to path to import dmenu_extended
+sys.path.insert(0, path.join(path.dirname(__file__), "..", "src"))
+import dmenu_extended as d
+from dmenu_extended import main
+
+
+def make_extension():
+    """Build an extension instance without running __init__.
+
+    extension.__init__ calls load_preferences which would read the real user
+    config from disk. Bypassing __init__ via __new__ gives a usable instance
+    whose download_plugins_json / download_plugins / update_plugins methods can
+    be exercised in isolation.
+    """
+    return main.extension.__new__(main.extension)
+
+
+# ---------------------------------------------------------------------------
+# Version class
+# ---------------------------------------------------------------------------
+
+
+def test_version_parses_first_three_components():
+    # A version string is split on "." and only the first three parts are kept.
+    v = main.Version("1.2.3.4")
+    assert v.parsed == [1, 2, 3]
+    # The original string is retained verbatim, including the dropped 4th part.
+    assert v.string == "1.2.3.4"
+
+
+def test_version_equality_and_ordering():
+    assert main.Version("1.2.3") == main.Version("1.2.3")
+    assert main.Version("1.2.3") != main.Version("1.2.4")
+    assert main.Version("1.2.3") < main.Version("1.2.4")
+    assert main.Version("1.3.0") > main.Version("1.2.9")
+    assert main.Version("2.0.0") >= main.Version("2.0.0")
+    assert main.Version("1.0.0") <= main.Version("1.0.1")
+
+
+def test_version_ordering_is_major_then_minor_then_patch():
+    # A larger major beats a smaller minor/patch.
+    assert main.Version("2.0.0") > main.Version("1.9.9")
+    # Equal major, larger minor wins.
+    assert main.Version("1.5.0") > main.Version("1.4.9")
+
+
+def test_version_two_component_string_breaks_equality():
+    # A two-component version produces a parsed list of length 2. __eq__ always
+    # indexes parsed[2], so comparing two such versions raises IndexError. This
+    # is a current quirk: Version assumes three components for equality.
+    v = main.Version("1.2")
+    assert v.parsed == [1, 2]
+    import pytest
+
+    with pytest.raises(IndexError):
+        _ = v == main.Version("1.2")
+
+
+def test_version_two_component_less_than_can_short_circuit():
+    # __lt__ only reaches parsed[2] when major and minor are equal. When the
+    # minor differs it short-circuits and never touches the missing index.
+    assert (main.Version("1.2") < main.Version("1.3")) is True
+
+
+# ---------------------------------------------------------------------------
+# provided_package_versions
+# ---------------------------------------------------------------------------
+
+
+def test_provided_package_versions_keys():
+    # The module advertises exactly two satisfiable packages.
+    assert set(main.provided_package_versions.keys()) == {"dmenu-extended", "python"}
+    assert isinstance(main.provided_package_versions["python"], main.Version)
+
+
+# ---------------------------------------------------------------------------
+# get_plugin_requirements
+# ---------------------------------------------------------------------------
+
+
+def test_get_plugin_requirements_new_format():
+    # The current index format uses a "requirements" dict of package -> version
+    # string. Each value is wrapped in a Version object.
+    reqs = main.get_plugin_requirements(
+        {"requirements": {"dmenu-extended": "0.2.0", "python": "3.6.0"}}
+    )
+    assert set(reqs.keys()) == {"dmenu-extended", "python"}
+    assert all(isinstance(v, main.Version) for v in reqs.values())
+    assert reqs["dmenu-extended"].string == "0.2.0"
+
+
+def test_get_plugin_requirements_legacy_min_version_nonzero():
+    # Legacy plugins used an integer "min_version". Any non-zero value maps to a
+    # dmenu-extended requirement of exactly 0.2.0 (the semantic-versioning
+    # cut-over point).
+    reqs = main.get_plugin_requirements({"min_version": 5})
+    assert {k: v.string for k, v in reqs.items()} == {"dmenu-extended": "0.2.0"}
+
+
+def test_get_plugin_requirements_legacy_min_version_zero():
+    # A zero min_version means no requirement.
+    assert main.get_plugin_requirements({"min_version": 0}) == {}
+
+
+def test_get_plugin_requirements_min_version_comment_is_printed(capsys):
+    # When a "_min_version_comment" is present alongside min_version, it is
+    # printed to stdout.
+    main.get_plugin_requirements(
+        {"min_version": 1, "_min_version_comment": "please upgrade"}
+    )
+    assert "please upgrade" in capsys.readouterr().out
+
+
+def test_get_plugin_requirements_returns_none_when_no_keys():
+    # A plugin entry with neither "requirements" nor "min_version" falls through
+    # every branch and returns None (not an empty dict). This is the root cause
+    # of the crash pinned in the next test.
+    assert main.get_plugin_requirements({"desc": "no requirements"}) is None
+
+
+# ---------------------------------------------------------------------------
+# unsatisfied_plugin_requirements
+# ---------------------------------------------------------------------------
+
+
+def test_unsatisfied_requirements_all_met_returns_empty():
+    # A requirement the running system satisfies yields no unsatisfied entries.
+    assert (
+        main.unsatisfied_plugin_requirements({"requirements": {"python": "0.0.1"}})
+        == {}
+    )
+
+
+def test_unsatisfied_requirements_version_too_high():
+    # A python requirement higher than the running interpreter is reported as
+    # unsatisfied, keyed by package with the required version string.
+    result = main.unsatisfied_plugin_requirements(
+        {"requirements": {"python": "99.0.0"}}
+    )
+    assert result == {"python": "99.0.0"}
+
+
+def test_unsatisfied_requirements_unknown_package_always_unsatisfied():
+    # A package that is not in provided_package_versions is always treated as
+    # unsatisfied, regardless of the requested version.
+    result = main.unsatisfied_plugin_requirements(
+        {"requirements": {"some-unknown-pkg": "1.0.0"}}
+    )
+    assert result == {"some-unknown-pkg": "1.0.0"}
+
+
+def test_unsatisfied_requirements_none_requirements_raises():
+    # When get_plugin_requirements returns None (no requirements key), this
+    # function calls .items() on None and raises AttributeError. Current quirk.
+    import pytest
+
+    with pytest.raises(AttributeError):
+        main.unsatisfied_plugin_requirements({"desc": "no requirements"})
+
+
+# ---------------------------------------------------------------------------
+# load_plugins
+# ---------------------------------------------------------------------------
+
+
+def test_load_plugins_seeds_settings_plugin_first():
+    # load_plugins always seeds the settings plugin (plugin_settings.py) as the
+    # first entry, then propagates the global d.launch_args onto it.
+    fake_plugins_mod = types.SimpleNamespace(__all__=[])
+    with (
+        mock.patch.object(main, "plugins", fake_plugins_mod),
+        mock.patch.object(main, "extension", return_value=mock.Mock()),
+        mock.patch.object(main, "d", main.dmenu()),
+    ):
+        main.d.launch_args = ["preselected"]
+        loaded = main.load_plugins()
+
+    assert len(loaded) == 1
+    assert loaded[0]["filename"] == "plugin_settings.py"
+    assert loaded[0]["plugin"].launch_args == ["preselected"]
+
+
+def test_load_plugins_survives_broken_plugin(capsys):
+    # A plugin name in plugins.__all__ that cannot be imported is caught: an
+    # error is printed and the loop continues. The settings plugin still loads.
+    fake_plugins_mod = types.SimpleNamespace(__all__=["does_not_exist_plugin_xyz"])
+    with (
+        mock.patch.object(main, "plugins", fake_plugins_mod),
+        mock.patch.object(main, "extension", return_value=mock.Mock()),
+        mock.patch.object(main, "d", main.dmenu()),
+    ):
+        main.d.launch_args = []
+        loaded = main.load_plugins()
+
+    assert len(loaded) == 1
+    assert loaded[0]["filename"] == "plugin_settings.py"
+    assert "Error loading plugin does_not_exist_plugin_xyz" in capsys.readouterr().out
+
+
+# ---------------------------------------------------------------------------
+# get_plugins (caching behaviour)
+# ---------------------------------------------------------------------------
+
+
+def test_get_plugins_loads_once_when_not_loaded():
+    inst = main.dmenu()
+    inst.plugins_loaded = False
+    with mock.patch.object(main, "load_plugins", return_value=["loaded"]) as lp:
+        out = inst.get_plugins()
+    assert lp.called
+    assert out == ["loaded"]
+
+
+def test_get_plugins_returns_cache_without_reloading():
+    # If plugins_loaded already holds a (truthy) value, get_plugins returns it
+    # and does NOT call load_plugins again.
+    inst = main.dmenu()
+    inst.plugins_loaded = [{"filename": "plugin_settings.py", "plugin": object()}]
+    with mock.patch.object(main, "load_plugins") as lp:
+        out = inst.get_plugins()
+    assert lp.called is False
+    assert out is inst.plugins_loaded
+
+
+def test_get_plugins_force_reloads():
+    # force=True reloads the plugins package and rebuilds the loaded list.
+    inst = main.dmenu()
+    inst.plugins_loaded = ["stale"]
+    with (
+        mock.patch.object(main, "load_plugins", return_value=["fresh"]) as lp,
+        mock.patch("importlib.reload") as reload_mock,
+    ):
+        out = inst.get_plugins(force=True)
+    assert lp.called
+    assert reload_mock.called
+    assert out == ["fresh"]
+
+
+# ---------------------------------------------------------------------------
+# plugins_available
+# ---------------------------------------------------------------------------
+
+
+def test_plugins_available_marks_submenus_and_sorts_by_length():
+    inst = main.dmenu()
+    cache_file = os.path.join(tempfile.mkdtemp(), "plugins.txt")
+
+    class FakeSubmenu:
+        is_submenu = True
+        title = "Settings"
+
+    class FakeNormal:
+        title = "Calculator"
+
+    fake_plugins = [
+        {"filename": "plugin_settings.py", "plugin": FakeSubmenu()},
+        {"filename": "plugin_calc.py", "plugin": FakeNormal()},
+    ]
+
+    with (
+        mock.patch.object(inst, "load_preferences"),
+        mock.patch.object(inst, "get_plugins", return_value=fake_plugins),
+        mock.patch.object(main, "file_cache_plugins", cache_file),
+    ):
+        inst.prefs = {"indicator_submenu": "->"}
+        out = inst.plugins_available()
+
+    # Submenu plugins get the indicator prefix; normal plugins keep their title.
+    # The list is sorted shortest-first, so "Calculator" (10 chars) precedes
+    # "-> Settings" (11 chars).
+    assert out == ["Calculator", "-> Settings"]
+    with open(cache_file) as f:
+        assert f.read() == "Calculator\n-> Settings\n"
+
+
+def test_plugins_available_forces_plugin_reload():
+    # plugins_available calls get_plugins(True) - it always forces a reload.
+    inst = main.dmenu()
+    cache_file = os.path.join(tempfile.mkdtemp(), "plugins.txt")
+
+    class FakeNormal:
+        title = "X"
+
+    with (
+        mock.patch.object(inst, "load_preferences"),
+        mock.patch.object(
+            inst,
+            "get_plugins",
+            return_value=[{"filename": "p.py", "plugin": FakeNormal()}],
+        ) as gp,
+        mock.patch.object(main, "file_cache_plugins", cache_file),
+    ):
+        inst.prefs = {"indicator_submenu": "->"}
+        inst.plugins_available()
+
+    gp.assert_called_once_with(True)
+
+
+# ---------------------------------------------------------------------------
+# download_plugins_json
+# ---------------------------------------------------------------------------
+
+
+def test_download_plugins_json_merges_all_index_urls():
+    # The index is fetched from every URL in plugins_index_urls and merged into
+    # a single dict (later URLs overwrite earlier keys via dict.update).
+    inst = make_extension()
+    inst.plugins_index_urls = ["http://example/a.json", "http://example/b.json"]
+    with mock.patch.object(inst, "download_json") as dj:
+        dj.side_effect = [
+            {"plugin_a": {"url": "ua", "sha1sum": "sa"}},
+            {"plugin_b": {"url": "ub", "sha1sum": "sb"}},
+        ]
+        merged = inst.download_plugins_json()
+
+    assert dj.call_count == 2
+    assert merged == {
+        "plugin_a": {"url": "ua", "sha1sum": "sa"},
+        "plugin_b": {"url": "ub", "sha1sum": "sb"},
+    }
+
+
+def test_download_plugins_json_error_exits():
+    # A failure fetching any index closes the wait message, shows an error menu,
+    # and exits the process via sys.exit().
+    import pytest
+
+    inst = make_extension()
+    inst.plugins_index_urls = ["http://example/a.json"]
+    with (
+        mock.patch.object(inst, "download_json", side_effect=Exception("boom")),
+        mock.patch.object(inst, "message_close") as mc,
+        mock.patch.object(inst, "menu") as menu,
+    ):
+        with pytest.raises(SystemExit):
+            inst.download_plugins_json()
+
+    assert mc.called
+    assert menu.call_args[0][0] == [
+        "Error: Could not connect to plugin repository.",
+        "Please check your internet connection and try again.",
+    ]
+
+
+# ---------------------------------------------------------------------------
+# download_plugins
+# ---------------------------------------------------------------------------
+
+
+def test_download_plugins_installs_selected_plugin(tmp_path):
+    # The happy path: an index entry carrying url + sha1sum + desc + (empty)
+    # requirements is offered, selected, downloaded via download_text, and
+    # written to path_plugins as <plugin_name>.py.
+    inst = make_extension()
+    plugins_json = {
+        "plugin_foo": {
+            "url": "http://example/foo.py",
+            "sha1sum": "abc123",
+            "desc": "Foo plugin",
+            "requirements": {},
+        }
+    }
+
+    with contextlib.ExitStack() as stack:
+        stack.enter_context(
+            mock.patch.object(inst, "download_plugins_json", return_value=plugins_json)
+        )
+        stack.enter_context(
+            mock.patch.object(
+                inst, "get_plugins", return_value=[{"filename": "plugin_settings.py"}]
+            )
+        )
+        select = stack.enter_context(
+            mock.patch.object(inst, "select", return_value="foo - Foo plugin")
+        )
+        stack.enter_context(mock.patch.object(inst, "message_open"))
+        stack.enter_context(mock.patch.object(inst, "message_close"))
+        dt = stack.enter_context(
+            mock.patch.object(inst, "download_text", return_value=b"# plugin source")
+        )
+        stack.enter_context(mock.patch.object(inst, "plugins_available"))
+        menu = stack.enter_context(mock.patch.object(inst, "menu"))
+        stack.enter_context(mock.patch.object(main, "path_plugins", str(tmp_path)))
+        inst.download_plugins()
+
+    # The selectable item has the "plugin_" prefix stripped for display.
+    assert select.call_args[0][0] == ["foo - Foo plugin"]
+    # download_text is called with the plugin's url.
+    dt.assert_called_once_with("http://example/foo.py")
+    # The file is written back WITH the plugin_ prefix.
+    written = tmp_path / "plugin_foo.py"
+    assert written.exists()
+    assert written.read_bytes() == b"# plugin source"
+    assert menu.call_args[0][0] == ["Plugin downloaded and installed successfully"]
+
+
+def test_download_plugins_no_new_plugins(tmp_path):
+    # When every index plugin is already installed, the menu reports that there
+    # are no new plugins and nothing is downloaded.
+    inst = make_extension()
+    plugins_json = {
+        "plugin_foo": {
+            "url": "u",
+            "sha1sum": "s",
+            "desc": "d",
+            "requirements": {},
+        }
+    }
+    with contextlib.ExitStack() as stack:
+        stack.enter_context(
+            mock.patch.object(inst, "download_plugins_json", return_value=plugins_json)
+        )
+        stack.enter_context(
+            mock.patch.object(
+                inst, "get_plugins", return_value=[{"filename": "plugin_foo.py"}]
+            )
+        )
+        menu = stack.enter_context(mock.patch.object(inst, "menu"))
+        dt = stack.enter_context(mock.patch.object(inst, "download_text"))
+        inst.download_plugins()
+
+    assert menu.call_args[0][0] == ["There are no new plugins to install"]
+    assert dt.called is False
+
+
+def test_download_plugins_unmet_requirements_blocks_install():
+    # A plugin whose requirements are not met is listed with a "Requires:"
+    # description and accept=False. Selecting it shows the unmet-dependencies
+    # message instead of downloading.
+    inst = make_extension()
+    plugins_json = {
+        "plugin_bar": {
+            "url": "u",
+            "sha1sum": "s",
+            "desc": "d",
+            "requirements": {"python": "99.0.0"},
+        }
+    }
+    with contextlib.ExitStack() as stack:
+        stack.enter_context(
+            mock.patch.object(inst, "download_plugins_json", return_value=plugins_json)
+        )
+        stack.enter_context(
+            mock.patch.object(
+                inst, "get_plugins", return_value=[{"filename": "plugin_settings.py"}]
+            )
+        )
+        select = stack.enter_context(
+            mock.patch.object(
+                inst, "select", return_value="bar - Requires: python => 99.0.0"
+            )
+        )
+        menu = stack.enter_context(mock.patch.object(inst, "menu"))
+        dt = stack.enter_context(mock.patch.object(inst, "download_text"))
+        inst.download_plugins()
+
+    # The displayed item carries the generated "Requires:" description.
+    assert select.call_args[0][0] == ["bar - Requires: python => 99.0.0"]
+    assert menu.call_args[0][0] == [
+        "The requested plugin has unmet dependencies, please update your system and try again"
+    ]
+    assert dt.called is False
+
+
+def test_download_plugins_entry_without_requirements_key_raises():
+    # An index entry that omits both "requirements" and "min_version" makes
+    # unsatisfied_plugin_requirements raise AttributeError, which propagates out
+    # of download_plugins. This pins the current fragility of the index format:
+    # a requirements (or min_version) key is effectively mandatory.
+    import pytest
+
+    inst = make_extension()
+    plugins_json = {
+        "plugin_baz": {"url": "u", "sha1sum": "s", "desc": "d"}  # no requirements
+    }
+    with (
+        mock.patch.object(inst, "download_plugins_json", return_value=plugins_json),
+        mock.patch.object(
+            inst, "get_plugins", return_value=[{"filename": "plugin_settings.py"}]
+        ),
+    ):
+        with pytest.raises(AttributeError):
+            inst.download_plugins()
+
+
+def test_download_plugins_missing_python_dependency_aborts(tmp_path):
+    # A plugin declaring a python dependency that cannot be imported fails the
+    # dependency check: the missing-dependency message is shown and the plugin
+    # is NOT written to disk.
+    inst = make_extension()
+    plugins_json = {
+        "plugin_dep": {
+            "url": "http://example/dep.py",
+            "sha1sum": "s",
+            "desc": "Needs a lib",
+            "requirements": {},
+            "dependencies": {"python": ["a_module_that_does_not_exist_xyz"]},
+        }
+    }
+    with contextlib.ExitStack() as stack:
+        stack.enter_context(
+            mock.patch.object(inst, "download_plugins_json", return_value=plugins_json)
+        )
+        stack.enter_context(
+            mock.patch.object(
+                inst, "get_plugins", return_value=[{"filename": "plugin_settings.py"}]
+            )
+        )
+        stack.enter_context(mock.patch.object(inst, "message_open"))
+        stack.enter_context(mock.patch.object(inst, "message_close"))
+        stack.enter_context(
+            mock.patch.object(inst, "select", side_effect=["dep - Needs a lib", 0])
+        )
+        stack.enter_context(mock.patch.object(main, "d", inst))
+        stack.enter_context(mock.patch.object(inst, "open_url"))
+        menu = stack.enter_context(mock.patch.object(inst, "menu"))
+        dt = stack.enter_context(mock.patch.object(inst, "download_text"))
+        stack.enter_context(mock.patch.object(main, "path_plugins", str(tmp_path)))
+        inst.download_plugins()
+
+    assert menu.call_args[0][0] == [
+        "Plugin has missing dependencies and therefore was not installed"
+    ]
+    assert dt.called is False
+    assert list(tmp_path.iterdir()) == []
+
+
+def test_download_plugins_missing_external_dependency_aborts(tmp_path):
+    # A plugin declaring an external (binary) dependency that is absent from the
+    # scanned binaries fails the dependency check the same way.
+    inst = make_extension()
+    plugins_json = {
+        "plugin_ext": {
+            "url": "http://example/ext.py",
+            "sha1sum": "s",
+            "desc": "Needs a binary",
+            "requirements": {},
+            "dependencies": {
+                "external": [{"name": "some_missing_binary", "url": "http://help"}]
+            },
+        }
+    }
+    with contextlib.ExitStack() as stack:
+        stack.enter_context(
+            mock.patch.object(inst, "download_plugins_json", return_value=plugins_json)
+        )
+        stack.enter_context(
+            mock.patch.object(
+                inst, "get_plugins", return_value=[{"filename": "plugin_settings.py"}]
+            )
+        )
+        stack.enter_context(mock.patch.object(inst, "message_open"))
+        stack.enter_context(mock.patch.object(inst, "message_close"))
+        stack.enter_context(
+            mock.patch.object(inst, "select", side_effect=["ext - Needs a binary", 0])
+        )
+        stack.enter_context(mock.patch.object(main, "d", inst))
+        stack.enter_context(
+            mock.patch.object(inst, "scan_binaries", return_value=["ls", "cat"])
+        )
+        open_url = stack.enter_context(mock.patch.object(inst, "open_url"))
+        menu = stack.enter_context(mock.patch.object(inst, "menu"))
+        dt = stack.enter_context(mock.patch.object(inst, "download_text"))
+        stack.enter_context(mock.patch.object(main, "path_plugins", str(tmp_path)))
+        inst.download_plugins()
+
+    # The missing-external message references the dependency's help url.
+    assert menu.call_args[0][0] == [
+        "Plugin has missing dependencies and therefore was not installed"
+    ]
+    # The help url is offered for opening.
+    assert open_url.call_args[0][0] == "http://help"
+    assert dt.called is False
+    assert list(tmp_path.iterdir()) == []
+
+
+# ---------------------------------------------------------------------------
+# update_plugins
+# ---------------------------------------------------------------------------
+
+
+def test_update_plugins_downloads_when_hash_differs(tmp_path):
+    # When the local sha1sum differs from the index sha1sum and the freshly
+    # downloaded copy verifies against the index, the old plugin is removed and
+    # the downloaded one is moved into place. wget downloads to /tmp.
+    inst = make_extension()
+    plugins_there = {"foo": {"url": "http://example/foo.py", "sha1sum": "REMOTE_SHA"}}
+
+    def command_output(command, split=True):
+        # The downloaded copy lives at /tmp/foo.py and matches the remote sha.
+        if command == "sha1sum /tmp/foo.py":
+            return ["REMOTE_SHA  /tmp/foo.py"]
+        # The local copy reports a different sha.
+        return ["LOCAL_SHA  " + command]
+
+    with contextlib.ExitStack() as stack:
+        stack.enter_context(mock.patch.object(inst, "message_open"))
+        stack.enter_context(mock.patch.object(inst, "message_close"))
+        stack.enter_context(
+            mock.patch.object(
+                inst,
+                "get_plugins",
+                return_value=[
+                    {"filename": "plugin_settings.py"},
+                    {"filename": "foo.py"},
+                ],
+            )
+        )
+        stack.enter_context(
+            mock.patch.object(inst, "download_plugins_json", return_value=plugins_there)
+        )
+        stack.enter_context(
+            mock.patch.object(inst, "command_output", side_effect=command_output)
+        )
+        menu = stack.enter_context(mock.patch.object(inst, "menu"))
+        call = stack.enter_context(mock.patch("subprocess.call"))
+        stack.enter_context(mock.patch("os.path.exists", return_value=False))
+        remove = stack.enter_context(mock.patch("os.remove"))
+        move = stack.enter_context(mock.patch("shutil.move"))
+        stack.enter_context(mock.patch.object(main, "path_plugins", str(tmp_path)))
+        inst.update_plugins()
+
+    # wget is invoked to download into /tmp.
+    assert call.call_args[0][0] == ["wget", "http://example/foo.py", "-P", "/tmp"]
+    # The stale local copy is removed and the verified download moved over it.
+    assert remove.call_args[0][0] == str(tmp_path) + "/foo.py"
+    assert move.call_args[0] == ("/tmp/foo.py", str(tmp_path) + "/foo.py")
+    assert menu.call_args[0][0] == ["foo was updated to the latest version"]
+
+
+def test_update_plugins_skips_when_hash_matches(tmp_path):
+    # When the local sha1sum already matches the index sha1sum, no download
+    # happens and the "no new updates" message is shown.
+    inst = make_extension()
+    plugins_there = {"foo": {"url": "u", "sha1sum": "SAME"}}
+
+    with contextlib.ExitStack() as stack:
+        stack.enter_context(mock.patch.object(inst, "message_open"))
+        stack.enter_context(mock.patch.object(inst, "message_close"))
+        stack.enter_context(
+            mock.patch.object(
+                inst,
+                "get_plugins",
+                return_value=[
+                    {"filename": "plugin_settings.py"},
+                    {"filename": "foo.py"},
+                ],
+            )
+        )
+        stack.enter_context(
+            mock.patch.object(inst, "download_plugins_json", return_value=plugins_there)
+        )
+        stack.enter_context(
+            mock.patch.object(inst, "command_output", return_value=["SAME  irrelevant"])
+        )
+        menu = stack.enter_context(mock.patch.object(inst, "menu"))
+        call = stack.enter_context(mock.patch("subprocess.call"))
+        stack.enter_context(mock.patch.object(main, "path_plugins", str(tmp_path)))
+        inst.update_plugins()
+
+    assert call.called is False
+    assert menu.call_args[0][0] == ["There are no new updates for installed plugins"]
+
+
+def test_update_plugins_requires_settings_plugin_present():
+    # update_plugins unconditionally calls plugins_here.remove("plugin_settings").
+    # If the settings plugin is somehow absent from the loaded list, this raises
+    # ValueError. Current quirk: the settings plugin is assumed always loaded.
+    import pytest
+
+    inst = make_extension()
+    with contextlib.ExitStack() as stack:
+        stack.enter_context(mock.patch.object(inst, "message_open"))
+        stack.enter_context(mock.patch.object(inst, "message_close"))
+        stack.enter_context(
+            mock.patch.object(
+                inst, "get_plugins", return_value=[{"filename": "foo.py"}]
+            )
+        )
+        stack.enter_context(
+            mock.patch.object(inst, "download_plugins_json", return_value={})
+        )
+        stack.enter_context(mock.patch.object(inst, "menu"))
+        with pytest.raises(ValueError):
+            inst.update_plugins()
+
+
+# ---------------------------------------------------------------------------
+# Plugin index format sanity (documents the expected entry shape)
+# ---------------------------------------------------------------------------
+
+
+def test_plugins_index_urls_point_at_raw_github():
+    # The settings plugin pulls the index from raw.githubusercontent.com for the
+    # three known plugin repositories.
+    inst = make_extension()
+    assert inst.base_url == "https://raw.githubusercontent.com"
+    assert len(inst.plugins_index_urls) == 3
+    assert all(
+        url.startswith("https://raw.githubusercontent.com")
+        and url.endswith("/plugins_index.json")
+        for url in inst.plugins_index_urls
+    )
+
+
+def test_module_path_cache_suffix():
+    # Sanity check that the imported package exposes the expected cache path,
+    # mirroring the existing test_main.py expectation.
+    assert d.path_cache[-len("dmenu-extended") :] == "dmenu-extended"

--- a/tests/test_preferences.py
+++ b/tests/test_preferences.py
@@ -1,0 +1,308 @@
+#!/usr/bin/env python3
+
+"""Characterisation tests for the preferences subsystem of dmenu-extended.
+
+These tests pin down the CURRENT behaviour of preference path resolution,
+load_json / save_json, and load_preferences / save_preferences (including the
+missing-key merge and the aliased_applications_format migration). They assert
+what the code does today, including its quirks, not what it ideally should do.
+
+Boundaries are mocked: the filesystem uses tmp paths, subprocess never spawns a
+real dmenu/rofi (the menu method and open_file are patched), and sys.exit is
+patched so the missing-config branch can be exercised without killing pytest.
+"""
+
+import copy
+import importlib
+import json
+import os
+import sys
+import tempfile
+
+import mock
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+
+from dmenu_extended import main
+
+
+# ---------------------------------------------------------------------------
+# Path / default_prefs resolution at module level
+# ---------------------------------------------------------------------------
+
+
+def test_path_base_is_under_config_dmenu_extended():
+    # path_base is hard-wired to ~/.config/dmenu-extended and does NOT honour
+    # XDG_CONFIG_HOME (only the cache path honours an env override).
+    assert main.path_base.endswith("/.config/dmenu-extended")
+
+
+def test_prefs_paths_derive_from_path_base():
+    assert main.path_prefs == main.path_base + "/config"
+    assert main.path_plugins == main.path_base + "/plugins"
+
+
+def test_file_prefs_is_a_txt_file_holding_json():
+    # The preferences file carries a .txt extension despite holding JSON.
+    assert main.file_prefs == main.path_prefs + "/dmenuExtended_preferences.txt"
+    assert main.file_prefs.endswith(".txt")
+
+
+def test_default_prefs_core_values():
+    # Pin a representative slice of the shipped defaults.
+    assert main.default_prefs["menu"] == "dmenu"
+    assert main.default_prefs["fileopener"] == "xdg-open"
+    assert main.default_prefs["filebrowser"] == "xdg-open"
+    assert main.default_prefs["webbrowser"] == "xdg-open"
+    assert main.default_prefs["alias_display_format"] == "{name}"
+    assert main.default_prefs["frequently_used"] == 0
+    assert main.default_prefs["include_applications"] is True
+    assert main.default_prefs["interactive_shell"] is False
+    # menu_arguments is the full dmenu styling argv list.
+    assert main.default_prefs["menu_arguments"][0] == "-b"
+    assert "-i" in main.default_prefs["menu_arguments"]
+
+
+def test_cache_path_honours_env_override_on_reload():
+    # Unlike path_base, path_cache honours DMENU_EXTENDED_CACHE_DIR. Guard the
+    # reload's setup_user_files side effect so the real ~/.config is untouched.
+    original = os.environ.get("DMENU_EXTENDED_CACHE_DIR")
+    os.environ["DMENU_EXTENDED_CACHE_DIR"] = "/tmp/dmenu-ext-test-cache-probe"
+    try:
+        with mock.patch.object(main, "setup_user_files"):
+            importlib.reload(main)
+        assert main.path_cache == "/tmp/dmenu-ext-test-cache-probe"
+    finally:
+        if original is None:
+            del os.environ["DMENU_EXTENDED_CACHE_DIR"]
+        else:
+            os.environ["DMENU_EXTENDED_CACHE_DIR"] = original
+        with mock.patch.object(main, "setup_user_files"):
+            importlib.reload(main)
+
+
+# ---------------------------------------------------------------------------
+# load_json
+# ---------------------------------------------------------------------------
+
+
+def test_load_json_returns_parsed_dict_for_valid_file():
+    menu = main.dmenu()
+    with tempfile.NamedTemporaryFile("w", suffix=".json", delete=False) as tf:
+        json.dump({"x": [1, 2, 3], "y": "z"}, tf)
+        name = tf.name
+    try:
+        assert menu.load_json(name) == {"x": [1, 2, 3], "y": "z"}
+    finally:
+        os.unlink(name)
+
+
+def test_load_json_returns_false_for_missing_file():
+    menu = main.dmenu()
+    assert menu.load_json("/nonexistent/definitely/missing.json") is False
+
+
+def test_load_json_invalid_json_returns_none_and_sets_default_prefs():
+    # On a JSONDecodeError load_json does NOT return False: it returns None
+    # (falls off the end of the function), assigns self.prefs to the SHARED
+    # default_prefs object, and prompts the user via self.menu().
+    menu = main.dmenu()
+    with tempfile.NamedTemporaryFile("w", suffix=".txt", delete=False) as tf:
+        tf.write("{ this is not valid json")
+        name = tf.name
+    try:
+        with mock.patch.object(menu, "menu", return_value="ignored") as mock_menu:
+            result = menu.load_json(name)
+        assert result is None
+        assert mock_menu.called
+        # self.prefs is the actual default_prefs object, not a copy.
+        assert menu.prefs is main.default_prefs
+    finally:
+        os.unlink(name)
+
+
+def test_load_json_invalid_json_offers_to_open_file_when_chosen():
+    # If the user's menu response equals the offered "Edit file manually"
+    # option, open_file(path) is invoked on the bad file.
+    menu = main.dmenu()
+    with tempfile.NamedTemporaryFile("w", suffix=".txt", delete=False) as tf:
+        tf.write("not json")
+        name = tf.name
+    try:
+        with mock.patch.object(menu, "menu", return_value="Edit file manually"):
+            with mock.patch.object(menu, "open_file") as mock_open:
+                menu.load_json(name)
+        mock_open.assert_called_once_with(name)
+    finally:
+        os.unlink(name)
+
+
+# ---------------------------------------------------------------------------
+# save_json / save_preferences
+# ---------------------------------------------------------------------------
+
+
+def test_save_json_writes_sorted_indented_json():
+    menu = main.dmenu()
+    target = os.path.join(tempfile.mkdtemp(), "out.json")
+    menu.save_json(target, {"b": 2, "a": 1})
+    with open(target) as f:
+        content = f.read()
+    # sort_keys=True, indent=4 (4 leading spaces, keys alphabetical).
+    assert content == '{\n    "a": 1,\n    "b": 2\n}'
+
+
+def test_save_preferences_writes_prefs_to_file_prefs():
+    menu = main.dmenu()
+    menu.prefs = {"menu": "dmenu", "frequently_used": 0}
+    target = os.path.join(tempfile.mkdtemp(), "prefs.txt")
+    with mock.patch.object(main, "file_prefs", target):
+        menu.save_preferences()
+    assert os.path.exists(target)
+    with open(target) as f:
+        assert json.load(f) == {"menu": "dmenu", "frequently_used": 0}
+
+
+def test_save_json_load_json_round_trip():
+    menu = main.dmenu()
+    target = os.path.join(tempfile.mkdtemp(), "rt.json")
+    data = {"watch_folders": ["~/"], "menu": "rofi", "nested": {"k": [1, 2]}}
+    menu.save_json(target, data)
+    assert menu.load_json(target) == data
+
+
+# ---------------------------------------------------------------------------
+# load_preferences: missing file
+# ---------------------------------------------------------------------------
+
+
+def test_load_preferences_missing_file_opens_file_and_exits():
+    # When the prefs file is absent, load_json returns False, so
+    # load_preferences opens the file for editing then calls sys.exit().
+    # open_file is patched to break the recursion it would otherwise cause
+    # (open_file itself calls load_preferences again).
+    menu = main.dmenu()
+    menu.prefs = False
+    with mock.patch.object(main, "file_prefs", "/nonexistent/missing-prefs.txt"):
+        with mock.patch.object(menu, "open_file") as mock_open:
+            with mock.patch.object(main.sys, "exit") as mock_exit:
+                menu.load_preferences()
+    mock_open.assert_called_once_with("/nonexistent/missing-prefs.txt")
+    assert mock_exit.called
+    # prefs is left as False after the missing-file branch.
+    assert menu.prefs is False
+
+
+# ---------------------------------------------------------------------------
+# load_preferences: idempotency
+# ---------------------------------------------------------------------------
+
+
+def test_load_preferences_is_noop_when_prefs_already_loaded():
+    # load_preferences only does work while self.prefs is False; once it is a
+    # dict, the method short-circuits and never re-reads the file.
+    menu = main.dmenu()
+    menu.prefs = {"already": "set"}
+    with mock.patch.object(menu, "load_json") as mock_load:
+        menu.load_preferences()
+    assert not mock_load.called
+    assert menu.prefs == {"already": "set"}
+
+
+# ---------------------------------------------------------------------------
+# load_preferences: complete config (no resave)
+# ---------------------------------------------------------------------------
+
+
+def test_load_preferences_complete_config_does_not_resave():
+    menu = main.dmenu()
+    menu.prefs = False
+    complete = copy.deepcopy(main.default_prefs)
+    complete["menu"] = "rofi"
+    with tempfile.NamedTemporaryFile("w", suffix=".txt", delete=False) as tf:
+        json.dump(complete, tf)
+        name = tf.name
+    try:
+        with mock.patch.object(main, "file_prefs", name):
+            with mock.patch.object(menu, "save_preferences") as mock_save:
+                menu.load_preferences()
+        assert not mock_save.called
+        assert menu.prefs["menu"] == "rofi"
+    finally:
+        os.unlink(name)
+
+
+# ---------------------------------------------------------------------------
+# load_preferences: partial config (missing-key merge)
+# ---------------------------------------------------------------------------
+
+
+def test_load_preferences_partial_config_fills_missing_keys_and_resaves():
+    # A config missing default keys gets them backfilled from default_prefs and
+    # is resaved. User-set values survive.
+    menu = main.dmenu()
+    menu.prefs = False
+    partial = {"menu": "rofi"}
+    saved_to = os.path.join(tempfile.mkdtemp(), "prefs.txt")
+    with open(saved_to, "w") as f:
+        json.dump(partial, f)
+    with mock.patch.object(main, "file_prefs", saved_to):
+        menu.load_preferences()
+    # User value preserved.
+    assert menu.prefs["menu"] == "rofi"
+    # A default-only key is now present.
+    assert menu.prefs["terminal"] == main.default_prefs["terminal"]
+    # All default keys are now present.
+    for key in main.default_prefs:
+        assert key in menu.prefs
+    # The resave actually hit disk with the merged content.
+    with open(saved_to) as f:
+        on_disk = json.load(f)
+    assert on_disk["menu"] == "rofi"
+    assert "terminal" in on_disk
+
+
+# ---------------------------------------------------------------------------
+# load_preferences: aliased_applications_format migration
+# ---------------------------------------------------------------------------
+
+
+def test_load_preferences_migrates_aliased_applications_format():
+    # The legacy key aliased_applications_format is migrated: its value is moved
+    # to alias_display_format and the old key is removed.
+    menu = main.dmenu()
+    menu.prefs = False
+    legacy = {"aliased_applications_format": "{name} LEGACY"}
+    target = os.path.join(tempfile.mkdtemp(), "prefs.txt")
+    with open(target, "w") as f:
+        json.dump(legacy, f)
+    with mock.patch.object(main, "file_prefs", target):
+        menu.load_preferences()
+    assert menu.prefs["alias_display_format"] == "{name} LEGACY"
+    assert "aliased_applications_format" not in menu.prefs
+    # Persisted to disk too.
+    with open(target) as f:
+        on_disk = json.load(f)
+    assert on_disk["alias_display_format"] == "{name} LEGACY"
+    assert "aliased_applications_format" not in on_disk
+
+
+def test_load_preferences_without_legacy_key_uses_default_alias_format():
+    # When neither alias_display_format nor the legacy key is present, the
+    # default alias_display_format is filled in (no migration path taken).
+    menu = main.dmenu()
+    menu.prefs = False
+    partial = {"menu": "dmenu"}
+    target = os.path.join(tempfile.mkdtemp(), "prefs.txt")
+    with open(target, "w") as f:
+        json.dump(partial, f)
+    with mock.patch.object(main, "file_prefs", target):
+        menu.load_preferences()
+    assert menu.prefs["alias_display_format"] == "{name}"
+    assert "aliased_applications_format" not in menu.prefs
+
+
+if __name__ == "__main__":
+    import pytest
+
+    pytest.main([__file__, "-q"])

--- a/tests/test_run_open_with.py
+++ b/tests/test_run_open_with.py
@@ -1,0 +1,438 @@
+#!/usr/bin/env python3
+
+"""Characterisation tests for run()'s colon-dispatch ("open X with Y") block.
+
+Pins the CURRENT behaviour of the branch in ``dmenu_extended.main.run()`` that
+fires when the menu selection contains a colon (``main.py`` ~lines 2248-2340).
+This is the "open X with Y" path: ``program:filter`` filters cached paths and
+runs/opens the chosen file, ``:filter`` prompts a sub-menu, a trailing ``;`` or
+``;;`` on the program switches to a terminal (held open with ``;;``), and the
+various path-with-colon forms either open the whole path, use the given program,
+or prompt for a binary from ``scan_binaries()``.
+
+The block calls ``sys.exit()`` on EVERY path, so each test wraps ``run()`` in
+``pytest.raises(SystemExit)``. Boundaries are mocked so nothing real launches and
+nothing touches the real config: ``init_menu``/``cache_load`` (setup),
+``load_plugins``/``retrieve_aliased_command`` (so the selection reaches the colon
+block unmolested), ``d.menu`` (the UI - first call yields the colon selection,
+later calls yield sub-menu picks), and ``d.execute`` / ``d.open_terminal`` /
+``d.scan_binaries`` / ``handle_command`` (the action sinks). The real
+dispatch/branching body runs untouched.
+
+The project targets Python 3.8, so contextlib.ExitStack is used instead of
+parenthesised ``with`` blocks (which are 3.9+ syntax).
+"""
+
+import contextlib
+import os
+import sys
+
+import mock
+import pytest
+
+# Add src directory to path to import dmenu_extended
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+
+from dmenu_extended import main
+
+
+# ---------------------------------------------------------------------------
+# Shared scaffolding
+# ---------------------------------------------------------------------------
+
+
+def patches(*context_managers):
+    """Enter several mock patchers under one ExitStack and yield their mocks."""
+
+    stack = contextlib.ExitStack()
+    mocks = [stack.enter_context(cm) for cm in context_managers]
+    return stack, mocks
+
+
+@pytest.fixture(autouse=True)
+def restore_module_state():
+    """Save and restore the global state that run() mutates.
+
+    ``run()`` (via ``init_menu`` in the real flow, and directly here) overwrites
+    ``main.d.prefs``/``main.d.launch_args`` and may flip ``main.debug``. Restore
+    them so cases do not bleed into one another.
+    """
+
+    saved_debug = main.debug
+    saved_prefs = main.d.prefs
+    saved_launch_args = main.d.launch_args
+
+    yield
+
+    main.debug = saved_debug
+    main.d.prefs = saved_prefs
+    main.d.launch_args = saved_launch_args
+
+
+@pytest.fixture
+def prefs():
+    """A fresh copy of the default preferences on the shared instance.
+
+    ``frequently_used`` is forced to 0 so the pre-colon ``else`` branch records
+    nothing and the selection flows straight into the colon block.
+    """
+
+    main.d.prefs = dict(main.default_prefs)
+    main.d.prefs["frequently_used"] = 0
+    main.d.launch_args = []
+    return main.d.prefs
+
+
+def drive_run(selection, cache, menu_side_effect, binaries=None):
+    """Drive ``run()`` so ``selection`` reaches the colon-dispatch block.
+
+    ``selection`` is what the first ``d.menu`` (cache picker) returns. Any later
+    ``d.menu`` calls inside the colon block consume the rest of
+    ``menu_side_effect``. ``binaries`` is what ``scan_binaries`` reports.
+
+    Returns the ExitStack (already entered) plus the four action-sink mocks:
+    (execute, open_terminal, scan_binaries, handle_command). The caller runs
+    inside the stack and asserts on the sinks.
+    """
+
+    if binaries is None:
+        binaries = []
+
+    (
+        stack,
+        (
+            _init,
+            _cache,
+            _plugins,
+            _alias,
+            menu,
+            execute,
+            open_terminal,
+            scan_binaries,
+            handle_command,
+        ),
+    ) = patches(
+        mock.patch.object(main, "init_menu", return_value=None),
+        mock.patch.object(main.d, "cache_load", return_value=cache),
+        mock.patch.object(main, "load_plugins", return_value=[]),
+        mock.patch.object(main.d, "retrieve_aliased_command", return_value=None),
+        mock.patch.object(main.d, "menu", side_effect=menu_side_effect),
+        mock.patch.object(main.d, "execute"),
+        mock.patch.object(main.d, "open_terminal"),
+        mock.patch.object(main.d, "scan_binaries", return_value=binaries),
+        mock.patch.object(main, "handle_command"),
+    )
+    return stack, (execute, open_terminal, scan_binaries, handle_command)
+
+
+# ---------------------------------------------------------------------------
+# ':filter' - empty program, sub-menu prompt (cmds[0] == "")
+# ---------------------------------------------------------------------------
+
+
+def test_empty_program_filters_cache_and_handles_chosen_item(prefs):
+    # ":pdf" has an empty program, so the cache is filtered to lines containing
+    # "pdf" and offered as a sub-menu; the chosen line goes to handle_command.
+    cache = "report.pdf\nnotes.txt\nmanual.pdf"
+    stack, (execute, open_terminal, _scan, handle_command) = drive_run(
+        ":pdf", cache, [":pdf", "report.pdf"]
+    )
+    with stack:
+        with pytest.raises(SystemExit):
+            main.run()
+
+    handle_command.assert_called_once_with(main.d, "report.pdf")
+    execute.assert_not_called()
+    open_terminal.assert_not_called()
+
+
+def test_empty_program_filter_offers_only_matching_cache_lines(prefs):
+    # The sub-menu is built from cache lines matching the filter substring only.
+    cache = "report.pdf\nnotes.txt\nmanual.pdf"
+    stack, (_execute, _open, _scan, _handle) = drive_run(
+        ":pdf", cache, [":pdf", "report.pdf"]
+    )
+    with stack:
+        with pytest.raises(SystemExit):
+            main.run()
+        # The second menu call (the sub-menu) received the filtered list.
+        offered = main.d.menu.call_args_list[1][0][0]
+
+    assert offered == ["report.pdf", "manual.pdf"]
+
+
+# ---------------------------------------------------------------------------
+# 'program:filter' - cmds[0] in scan_binaries()
+# ---------------------------------------------------------------------------
+
+
+def test_program_in_binaries_filters_paths_and_executes(prefs):
+    # "vlc:mp4" - vlc is a known binary, so cache PATHS (lines with "/") are
+    # filtered to those containing "mp4", the pick is appended, and execute runs
+    # "<program> <filename>" (no terminal, run_withshell is False).
+    cache = "/home/u/a.mp4\n/home/u/b.txt\n/home/u/c.mp4\nplainword"
+    stack, (execute, open_terminal, _scan, handle_command) = drive_run(
+        "vlc:mp4", cache, ["vlc:mp4", "/home/u/a.mp4"], binaries=["vlc"]
+    )
+    with stack:
+        with pytest.raises(SystemExit):
+            main.run()
+
+    execute.assert_called_once_with("vlc /home/u/a.mp4")
+    open_terminal.assert_not_called()
+    handle_command.assert_not_called()
+
+
+def test_program_in_binaries_path_submenu_excludes_non_path_lines(prefs):
+    # The path sub-menu only ever contains cache lines that have a "/" in them;
+    # the "mp4" filter then narrows that further.
+    cache = "/home/u/a.mp4\n/home/u/b.txt\n/home/u/c.mp4\nplainword"
+    stack, (_execute, _open, _scan, _handle) = drive_run(
+        "vlc:mp4", cache, ["vlc:mp4", "/home/u/a.mp4"], binaries=["vlc"]
+    )
+    with stack:
+        with pytest.raises(SystemExit):
+            main.run()
+        offered = main.d.menu.call_args_list[1][0][0]
+
+    assert offered == ["/home/u/a.mp4", "/home/u/c.mp4"]
+
+
+def test_program_in_binaries_empty_filter_offers_all_path_lines(prefs):
+    # "vlc:" has an empty filter (cmds[1] == ""), so no extra narrowing happens
+    # and every path line in the cache is offered.
+    cache = "/home/u/a.mp4\n/home/u/b.txt\nplainword"
+    stack, (execute, _open, _scan, _handle) = drive_run(
+        "vlc:", cache, ["vlc:", "/home/u/b.txt"], binaries=["vlc"]
+    )
+    with stack:
+        with pytest.raises(SystemExit):
+            main.run()
+        offered = main.d.menu.call_args_list[1][0][0]
+
+    assert offered == ["/home/u/a.mp4", "/home/u/b.txt"]
+    execute.assert_called_once_with("vlc /home/u/b.txt")
+
+
+def test_program_in_binaries_quotes_filename_with_spaces(prefs):
+    # A chosen filename containing a space is wrapped in double quotes before
+    # being appended to the program.
+    cache = "/home/u/my file.mp4"
+    stack, (execute, _open, _scan, _handle) = drive_run(
+        "vlc:mp4", cache, ["vlc:mp4", "/home/u/my file.mp4"], binaries=["vlc"]
+    )
+    with stack:
+        with pytest.raises(SystemExit):
+            main.run()
+
+    execute.assert_called_once_with('vlc "/home/u/my file.mp4"')
+
+
+def test_program_in_binaries_expands_user_in_chosen_filename(prefs):
+    # The chosen filename is passed through os.path.expanduser, so a leading "~"
+    # becomes the home directory.
+    cache = "~/notes.mp4"
+    stack, (execute, _open, _scan, _handle) = drive_run(
+        "vlc:mp4", cache, ["vlc:mp4", "~/notes.mp4"], binaries=["vlc"]
+    )
+    expected_path = os.path.expanduser("~/notes.mp4")
+    with stack:
+        with pytest.raises(SystemExit):
+            main.run()
+
+    execute.assert_called_once_with("vlc " + expected_path)
+
+
+# ---------------------------------------------------------------------------
+# 'command;:' and 'command;;:' - run_withshell / shell_hold parsing
+# ---------------------------------------------------------------------------
+
+
+def test_single_semicolon_opens_terminal_without_hold(prefs):
+    # "vlc;:mp4" - the single trailing ";" on the program turns on run_withshell
+    # but NOT shell_hold, so the command is sent to open_terminal with hold=False.
+    cache = "/home/u/a.mp4"
+    stack, (execute, open_terminal, _scan, _handle) = drive_run(
+        "vlc;:mp4", cache, ["vlc;:mp4", "/home/u/a.mp4"], binaries=["vlc"]
+    )
+    with stack:
+        with pytest.raises(SystemExit):
+            main.run()
+
+    open_terminal.assert_called_once_with("vlc /home/u/a.mp4", False)
+    execute.assert_not_called()
+
+
+def test_double_semicolon_opens_terminal_with_hold(prefs):
+    # "vlc;;:mp4" - the double trailing ";;" turns on both run_withshell and
+    # shell_hold, so open_terminal is called with hold=True.
+    cache = "/home/u/a.mp4"
+    stack, (execute, open_terminal, _scan, _handle) = drive_run(
+        "vlc;;:mp4", cache, ["vlc;;:mp4", "/home/u/a.mp4"], binaries=["vlc"]
+    )
+    with stack:
+        with pytest.raises(SystemExit):
+            main.run()
+
+    open_terminal.assert_called_once_with("vlc /home/u/a.mp4", True)
+    execute.assert_not_called()
+
+
+def test_semicolons_stripped_from_program_before_binary_lookup(prefs):
+    # The ";" characters are removed from cmds[0] before the scan_binaries
+    # membership test, so the bare "vlc" (not "vlc;") must be a known binary for
+    # the terminal path to fire.
+    cache = "/home/u/a.mp4"
+    stack, (_execute, open_terminal, _scan, _handle) = drive_run(
+        "vlc;:mp4", cache, ["vlc;:mp4", "/home/u/a.mp4"], binaries=["vlc"]
+    )
+    with stack:
+        with pytest.raises(SystemExit):
+            main.run()
+
+    # Command begins with the de-semicoloned program name.
+    assert open_terminal.call_args[0][0].startswith("vlc ")
+
+
+# ---------------------------------------------------------------------------
+# os.path.exists(out) - the whole selection is an existing path with a colon
+# ---------------------------------------------------------------------------
+
+
+def test_whole_path_with_colon_that_exists_goes_to_handle_command(prefs, tmp_path):
+    # A real on-disk file whose name contains a colon is not a program-with-arg;
+    # the entire selection is handed to handle_command verbatim.
+    colon_file = tmp_path / "file:name.txt"
+    colon_file.write_text("x")
+    out = str(colon_file)
+    stack, (execute, open_terminal, _scan, handle_command) = drive_run(out, out, [out])
+    with stack:
+        with pytest.raises(SystemExit):
+            main.run()
+
+    handle_command.assert_called_once_with(main.d, out)
+    execute.assert_not_called()
+    open_terminal.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# cmds[0].find('/') != -1 - first item is a path
+# ---------------------------------------------------------------------------
+
+
+def test_path_with_trailing_colon_prompts_for_binary(prefs):
+    # "/home/u/notes.txt:" - the path does not exist and ends in ":", so the user
+    # is prompted with scan_binaries() and the picked binary is wired up to open
+    # the path (colon stripped, single-quoted) via execute.
+    out = "/home/u/notes.txt:"
+    stack, (execute, open_terminal, scan_binaries, handle_command) = drive_run(
+        out, out, [out, "vim"], binaries=["vim", "nano"]
+    )
+    with stack:
+        with pytest.raises(SystemExit):
+            main.run()
+
+    scan_binaries.assert_called()
+    execute.assert_called_once_with("vim '/home/u/notes.txt'")
+    open_terminal.assert_not_called()
+    handle_command.assert_not_called()
+
+
+def test_path_with_trailing_colon_expands_user(prefs):
+    # The trailing-colon prompt path expands "~" in the (colon-stripped) path.
+    out = "~/notes.txt:"
+    stack, (execute, _open, _scan, _handle) = drive_run(
+        out, out, [out, "vim"], binaries=["vim"]
+    )
+    expected = os.path.expanduser("~/notes.txt")
+    with stack:
+        with pytest.raises(SystemExit):
+            main.run()
+
+    execute.assert_called_once_with("vim '" + expected + "'")
+
+
+def test_path_with_second_item_uses_it_as_opener(prefs):
+    # "/home/u/notes.txt:vim" - path does not exist, does not end in ":", and a
+    # second item is supplied, so cmds[1] is used directly as the opener: the
+    # command is "<opener> '<expanded path>'". No binary prompt is shown - the
+    # only d.menu call is the cache picker (scan_binaries IS still hit, once, by
+    # the earlier "cmds[0] in d.scan_binaries()" membership check on the path).
+    out = "/home/u/notes.txt:vim"
+    stack, (execute, open_terminal, _scan, handle_command) = drive_run(
+        out, out, [out], binaries=["vim"]
+    )
+    with stack:
+        with pytest.raises(SystemExit):
+            main.run()
+        # No sub-menu prompt: d.menu was called exactly once (the cache picker).
+        menu_call_count = main.d.menu.call_count
+
+    execute.assert_called_once_with("vim '/home/u/notes.txt'")
+    assert menu_call_count == 1
+    open_terminal.assert_not_called()
+    handle_command.assert_not_called()
+
+
+def test_path_with_empty_second_item_prompts_for_binary(prefs):
+    # The "path, no usable second item, not a trailing colon" branch. The raw
+    # selection ends in whitespace (so out[-1] != ":") but cmds[1] strips to "",
+    # which sends control to the prompt: scan_binaries() is offered and the pick
+    # opens the path.
+    out = "/home/u/notes.txt:  "
+    stack, (execute, open_terminal, scan_binaries, _handle) = drive_run(
+        out, out, [out, "nano"], binaries=["nano"]
+    )
+    with stack:
+        with pytest.raises(SystemExit):
+            main.run()
+
+    # cmds[1] strips to "", out[-1] is a space (not ":"), so the user is prompted
+    # with scan_binaries() and the result opens the path.
+    scan_binaries.assert_called()
+    execute.assert_called_once_with("nano '/home/u/notes.txt'")
+    open_terminal.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# 'Cant find X' fallback
+# ---------------------------------------------------------------------------
+
+
+def test_unknown_program_shows_cant_find_message(prefs):
+    # "nosuchprog:arg" - cmds[0] is non-empty, not a known binary, the whole
+    # thing is not an existing path, and cmds[0] has no "/", so the final else
+    # shows the "Cant find ..., is it installed?" message and exits.
+    out = "nosuchprog:arg"
+    stack, (execute, open_terminal, _scan, handle_command) = drive_run(
+        out, "somecache", [out, "ignored"], binaries=["vlc", "vim"]
+    )
+    with stack:
+        with pytest.raises(SystemExit):
+            main.run()
+        # The (single) colon-block menu call carried the fallback message.
+        message = main.d.menu.call_args_list[1][0][0]
+
+    assert message == ["Cant find nosuchprog, is it installed?"]
+    execute.assert_not_called()
+    open_terminal.assert_not_called()
+    handle_command.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Exit guarantee - every colon path ends in sys.exit()
+# ---------------------------------------------------------------------------
+
+
+def test_colon_block_always_exits(prefs):
+    # The whole colon block falls through to a shared sys.exit(); even the
+    # do-nothing-useful "Cant find" branch terminates the process.
+    out = "unknown:thing"
+    stack, _sinks = drive_run(out, "cache", [out, "x"], binaries=[])
+    with stack:
+        with pytest.raises(SystemExit):
+            main.run()
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([__file__, "-q"]))

--- a/tests/test_run_store_modification.py
+++ b/tests/test_run_store_modification.py
@@ -1,0 +1,547 @@
+#!/usr/bin/env python3
+
+"""Characterisation tests for the store-modification block inside run().
+
+Pins the CURRENT behaviour of the ``out[0] in "+-"`` branch of
+``dmenu_extended.main.run()`` (main.py:1956-2238). A selection that begins with
+``+`` or ``-`` is treated as a request to add/remove an item (plain or aliased)
+from ``prefs['include_items']``, the on-disk scanned cache, and the
+aliases-lookup JSON. This block:
+
+  - splits the input on ``#`` into a command and an optional alias,
+  - scans ``include_items`` to decide whether the item is already in the store
+    (the ``found_in_store`` loop),
+  - flips ``+`` -> ``-`` (or ``-`` -> ``+``) via a confirmation menu when the
+    item's presence contradicts the requested action,
+  - rewrites the scanned cache (prepend + ``sort(key=len)`` for additions, or
+    ``list.remove`` for removals),
+  - updates the aliases-lookup JSON for aliased additions,
+  - calls ``save_preferences()`` and ``cache_save()``, then shows a feedback
+    menu and ``sys.exit()``.
+
+These assert the actual behaviour today, INCLUDING quirks (e.g. the dead
+``cache_scanned is False`` branch that actually raises ``TypeError`` because of
+the ``[:-1]`` slice on a missing cache file). Boundaries are mocked: the menu
+UI (``menu``/``message_open``/``message_close``), the cache loader, plugin
+loading and ``init_menu``; the real dispatch body runs and touches only the
+tmp_path files we redirect the module globals to.
+
+The project targets Python 3.8, so contextlib.ExitStack is used instead of
+parenthesised ``with`` blocks (which are 3.9+ syntax).
+"""
+
+import contextlib
+import json
+import os
+import sys
+
+import mock
+import pytest
+
+# Add src directory to path to import dmenu_extended
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+
+from dmenu_extended import main
+
+
+def patches(*context_managers):
+    """Enter several mock patchers under one ExitStack and return their mocks."""
+
+    stack = contextlib.ExitStack()
+    mocks = [stack.enter_context(cm) for cm in context_managers]
+    return stack, mocks
+
+
+@pytest.fixture(autouse=True)
+def restore_module_state():
+    """Save and restore the shared instance state the block mutates.
+
+    ``run()`` operates on the module-level ``main.d`` singleton and mutates its
+    ``prefs`` (notably ``include_items``) and ``launch_args``. Restore them so
+    cases do not bleed into one another.
+    """
+
+    saved_prefs = main.d.prefs
+    saved_launch_args = main.d.launch_args
+    saved_debug = main.debug
+
+    yield
+
+    main.d.prefs = saved_prefs
+    main.d.launch_args = saved_launch_args
+    main.debug = saved_debug
+
+
+@pytest.fixture
+def store(tmp_path):
+    """Redirect the cache, aliases-lookup and prefs files into tmp_path.
+
+    Returns an object exposing the three paths plus helpers to read them back.
+    The module reads ``main.file_cache`` / ``main.file_cache_aliasesLookup`` /
+    ``main.file_prefs`` as globals at call time, so monkeypatching the module
+    attributes is enough to keep every write inside tmp_path.
+    """
+
+    cache_path = str(tmp_path / "all.txt")
+    aliases_path = str(tmp_path / "aliases_lookup.json")
+    prefs_path = str(tmp_path / "preferences.txt")
+
+    main.file_cache = cache_path
+    main.file_cache_aliasesLookup = aliases_path
+    main.file_prefs = prefs_path
+
+    # dict() is a shallow copy: default_prefs["include_items"] is a shared list
+    # that the block mutates in place. Give each test its own list so appends do
+    # not leak into default_prefs (and thus into later tests).
+    main.d.prefs = dict(main.default_prefs)
+    main.d.prefs["include_items"] = []
+    main.d.launch_args = []
+    main.debug = False
+
+    class Store:
+        cache = cache_path
+        aliases = aliases_path
+        prefs = prefs_path
+
+        def write_cache(self, lines):
+            with open(cache_path, "w") as f:
+                for line in lines:
+                    f.write(line + "\n")
+
+        def write_aliases(self, items):
+            with open(aliases_path, "w") as f:
+                json.dump(items, f)
+
+        def read_cache_lines(self):
+            with open(cache_path) as f:
+                # The block stores the cache as a list and cache_save writes one
+                # item per line with a trailing newline.
+                return f.read().split("\n")
+
+        def read_aliases(self):
+            with open(aliases_path) as f:
+                return json.load(f)
+
+        def read_prefs(self):
+            with open(prefs_path) as f:
+                return json.load(f)
+
+    return Store()
+
+
+def drive_run(selection, menu_side_effect=None):
+    """Run main.run() with everything up to the store block mocked out.
+
+    ``selection`` becomes the first menu() result (so ``out`` inside run()).
+    ``menu_side_effect``, if given, is used as the menu mock's side_effect so a
+    test can script the later confirmation/feedback menu answers; otherwise the
+    first call returns ``selection`` and subsequent calls return "".
+
+    Returns the menu mock so callers can inspect the prompts that were shown.
+    """
+
+    if menu_side_effect is None:
+        menu_side_effect = [selection, ""]
+
+    menu_mock = mock.Mock(side_effect=menu_side_effect)
+
+    stack, _ = patches(
+        mock.patch.object(main, "init_menu", return_value=None),
+        mock.patch.object(main.d, "cache_load", return_value="ignored"),
+        mock.patch.object(main.d, "menu", menu_mock),
+        mock.patch.object(main, "load_plugins", return_value=[]),
+        mock.patch.object(main.d, "retrieve_aliased_command", return_value=None),
+        mock.patch.object(main.d, "message_open"),
+        mock.patch.object(main.d, "message_close"),
+        mock.patch.object(main, "frequent_commands_store"),
+    )
+    with stack:
+        with pytest.raises(SystemExit):
+            main.run()
+    return menu_mock
+
+
+# ---------------------------------------------------------------------------
+# Adding plain items
+# ---------------------------------------------------------------------------
+
+
+def test_add_plain_item_appends_to_include_items(store):
+    # "+firefox" with firefox absent from the store: the bare command is
+    # appended to include_items.
+    store.write_cache(["aaaa", "bb"])
+    store.write_aliases([])
+
+    drive_run("+firefox")
+
+    assert "firefox" in main.d.prefs["include_items"]
+
+
+def test_add_plain_item_prepends_to_cache_then_sorts_by_length(store):
+    # On addition the new command is prepended to the scanned cache list, then
+    # the whole list is sorted by length (shortest first). cache_save writes one
+    # item per line plus a trailing newline (yielding a trailing empty element).
+    store.write_cache(["aaaa", "bb", "cccccc"])
+    store.write_aliases([])
+
+    drive_run("+ff")
+
+    lines = store.read_cache_lines()
+    # Sorted ascending by len: "ff" (2), "bb" (2), "aaaa" (4), "cccccc" (6).
+    # "ff" and "bb" are both length 2; the prepend puts "ff" first and a stable
+    # sort keeps it ahead of "bb".
+    assert lines == ["ff", "bb", "aaaa", "cccccc", ""]
+
+
+def test_add_plain_item_saves_preferences_to_disk(store):
+    # save_preferences() is called at the end, writing the mutated include_items
+    # out to the (tmp) prefs file as json.
+    store.write_cache(["xxxx"])
+    store.write_aliases([])
+
+    drive_run("+newcmd")
+
+    saved = store.read_prefs()
+    assert "newcmd" in saved["include_items"]
+
+
+def test_add_plain_item_feedback_message_and_exit(store):
+    # The final feedback menu reports the addition, then run() exits.
+    store.write_cache(["xxxx"])
+    store.write_aliases([])
+
+    menu_mock = drive_run("+newcmd")
+
+    last_prompt = menu_mock.call_args_list[-1][0][0]
+    assert last_prompt == "New item (newcmd) added to cache."
+
+
+# ---------------------------------------------------------------------------
+# Adding aliased items ([alias, command] pairs)
+# ---------------------------------------------------------------------------
+
+
+def test_add_aliased_item_appends_pair_to_include_items(store):
+    # "+vim#My Editor" splits on "#": command="vim", alias="My Editor". The
+    # [alias, command] pair is appended to include_items.
+    store.write_cache(["aaaa"])
+    store.write_aliases([])
+
+    drive_run("+vim#My Editor")
+
+    assert ["My Editor", "vim"] in main.d.prefs["include_items"]
+
+
+def test_add_aliased_item_writes_alias_into_lookup_json(store):
+    # The [alias, command] pair is also appended to the aliases-lookup json.
+    store.write_cache(["aaaa"])
+    store.write_aliases([])
+
+    drive_run("+vim#My Editor")
+
+    assert ["My Editor", "vim"] in store.read_aliases()
+
+
+def test_add_aliased_item_prepends_formatted_alias_to_cache(store):
+    # The cache receives the *formatted* alias (format_alias with default
+    # alias_display_format "{name}" and empty indicator yields just the name),
+    # prepended then length-sorted.
+    store.write_cache(["aaaaaaaa"])
+    store.write_aliases([])
+
+    drive_run("+vim#Ed")
+
+    lines = store.read_cache_lines()
+    # "Ed" (2) sorts before "aaaaaaaa" (8); trailing "" from cache_save.
+    assert lines == ["Ed", "aaaaaaaa", ""]
+
+
+def test_add_aliased_item_not_duplicated_in_lookup(store):
+    # If the [alias, command] pair already exists in the lookup json it is not
+    # appended a second time (the "not in aliases" guard).
+    store.write_cache(["aaaa"])
+    store.write_aliases([["My Editor", "vim"]])
+
+    drive_run("+vim#My Editor")
+
+    aliases = store.read_aliases()
+    assert aliases.count(["My Editor", "vim"]) == 1
+
+
+def test_add_aliased_item_feedback_mentions_alias(store):
+    store.write_cache(["aaaa"])
+    store.write_aliases([])
+
+    menu_mock = drive_run("+vim#My Editor")
+
+    last_prompt = menu_mock.call_args_list[-1][0][0]
+    assert last_prompt == "New item (vim aliased as 'My Editor') added to cache."
+
+
+# ---------------------------------------------------------------------------
+# Removing plain items
+#
+# QUIRK: the found_in_store matching loop only inspects list (aliased) items.
+# A plain *string* entry in include_items is never matched, so "-firefox" with
+# a plain string "firefox" present is reported as "not found in store" and the
+# action flips to "+", duplicating the entry instead of removing it. The
+# plain-removal codepath (include_items.remove(command) with alias is None) is
+# therefore unreachable through this UI. These tests pin that behaviour.
+# ---------------------------------------------------------------------------
+
+
+def test_remove_plain_string_item_is_reported_not_found(store):
+    # "-firefox" with a plain string "firefox" in the store: the loop never
+    # matches it, so found_in_store stays False and a "not found in store"
+    # confirmation is shown offering to ADD it.
+    store.write_cache(["firefox", "other"])
+    store.write_aliases([])
+    main.d.prefs["include_items"] = ["firefox", "keepme"]
+
+    menu_mock = drive_run("-firefox", menu_side_effect=["-firefox", "declined"])
+
+    confirm_prompt = menu_mock.call_args_list[1][0][0]
+    assert "Command 'firefox' was not found in store" in confirm_prompt
+    # Declined, so nothing was removed; the string entry is still present.
+    assert main.d.prefs["include_items"] == ["firefox", "keepme"]
+
+
+def test_remove_plain_string_item_accepting_flip_duplicates_it(store):
+    # Accepting the "Add to store" offer flips action to "+" and appends the
+    # command, so the plain string ends up listed twice rather than removed.
+    store.write_cache(["firefox", "other"])
+    store.write_aliases([])
+    main.d.prefs["include_items"] = ["firefox"]
+
+    add_option = main.d.prefs["indicator_submenu"] + " Add to store"
+    menu_mock = drive_run("-firefox", menu_side_effect=["-firefox", add_option, ""])
+
+    assert main.d.prefs["include_items"].count("firefox") == 2
+    # The feedback reports an addition, confirming the flip.
+    assert menu_mock.call_args_list[-1][0][0] == "New item (firefox) added to cache."
+
+
+# ---------------------------------------------------------------------------
+# Removing aliased items
+# ---------------------------------------------------------------------------
+
+
+def test_remove_aliased_item_by_displayed_alias_removes_pair(store):
+    # "-My Editor": command="My Editor". The loop's "-" path matches on
+    # `command == d.format_alias(item[0], item[1])`; with the default format
+    # ("{name}", no indicator) format_alias yields "My Editor", so the pair
+    # ["My Editor", "vim"] is matched, found_in_store becomes True, and the pair
+    # is removed from include_items.
+    store.write_cache(["My Editor", "other"])
+    store.write_aliases([["My Editor", "vim"]])
+    main.d.prefs["include_items"] = [["My Editor", "vim"]]
+
+    drive_run("-My Editor")
+
+    assert ["My Editor", "vim"] not in main.d.prefs["include_items"]
+
+
+def test_remove_aliased_item_removes_formatted_alias_from_cache(store):
+    store.write_cache(["My Editor", "other"])
+    store.write_aliases([["My Editor", "vim"]])
+    main.d.prefs["include_items"] = [["My Editor", "vim"]]
+
+    drive_run("-My Editor")
+
+    lines = store.read_cache_lines()
+    assert "My Editor" not in lines
+    assert "other" in lines
+
+
+def test_remove_aliased_item_feedback_mentions_alias(store):
+    store.write_cache(["My Editor"])
+    store.write_aliases([["My Editor", "vim"]])
+    main.d.prefs["include_items"] = [["My Editor", "vim"]]
+
+    menu_mock = drive_run("-My Editor")
+
+    last_prompt = menu_mock.call_args_list[-1][0][0]
+    assert last_prompt == "Existing alias (My Editor) removed from cache."
+
+
+# ---------------------------------------------------------------------------
+# The + -> - flip ("already in store") prompt
+# ---------------------------------------------------------------------------
+
+
+def test_add_existing_aliased_item_prompts_to_remove_then_flips_to_removal(store):
+    # "+vim#My Editor" while the [alias, command] pair is already in
+    # include_items: found_in_store is True (the "+" branch matches alias ==
+    # item[0]), so a confirmation menu offers "-> Remove from store". Answering
+    # with that option flips action to "-" and the pair is removed.
+    store.write_cache(["My Editor", "other"])
+    store.write_aliases([["My Editor", "vim"]])
+    main.d.prefs["include_items"] = [["My Editor", "vim"]]
+
+    remove_option = main.d.prefs["indicator_submenu"] + " Remove from store"
+    # First menu() = the original selection; second = the confirmation; the
+    # answer must equal the offered option to proceed, then a feedback menu.
+    menu_mock = drive_run(
+        "+vim#My Editor", menu_side_effect=["+vim#My Editor", remove_option, ""]
+    )
+
+    assert ["My Editor", "vim"] not in main.d.prefs["include_items"]
+    # The confirmation prompt announces the alias is already in the store.
+    confirm_prompt = menu_mock.call_args_list[1][0][0]
+    assert "already in store" in confirm_prompt
+    # And the final feedback reports a removal (action flipped to "-").
+    assert menu_mock.call_args_list[-1][0][0].startswith("Existing alias")
+
+
+def test_add_existing_aliased_item_declined_exits_without_change(store):
+    # If the confirmation answer is NOT the offered option, the block sys.exit()s
+    # immediately and include_items is left untouched.
+    store.write_cache(["My Editor"])
+    store.write_aliases([["My Editor", "vim"]])
+    main.d.prefs["include_items"] = [["My Editor", "vim"]]
+
+    drive_run("+vim#My Editor", menu_side_effect=["+vim#My Editor", "no thanks"])
+
+    # No flip, no removal: the pair is still present.
+    assert main.d.prefs["include_items"] == [["My Editor", "vim"]]
+
+
+def test_add_existing_plain_string_appends_without_any_prompt(store):
+    # QUIRK companion: "+firefox" while a plain string "firefox" is in the store
+    # does NOT find it (the loop ignores non-list items), so no confirmation is
+    # shown and the command is appended a second time. Only the original
+    # selection menu and the final feedback menu are shown (no confirmation in
+    # between).
+    store.write_cache(["firefox"])
+    store.write_aliases([])
+    main.d.prefs["include_items"] = ["firefox"]
+
+    menu_mock = drive_run("+firefox")
+
+    assert main.d.prefs["include_items"].count("firefox") == 2
+    # Exactly two menu calls: selection + feedback, no confirmation prompt.
+    assert menu_mock.call_count == 2
+    assert menu_mock.call_args_list[-1][0][0] == "New item (firefox) added to cache."
+
+
+def test_add_existing_aliased_item_prompt_mentions_alias(store):
+    # For an aliased addition that already exists, the confirmation prompt is
+    # phrased in terms of the alias rather than the command.
+    store.write_cache(["My Editor"])
+    store.write_aliases([["My Editor", "vim"]])
+    main.d.prefs["include_items"] = [["My Editor", "vim"]]
+
+    remove_option = main.d.prefs["indicator_submenu"] + " Remove from store"
+    menu_mock = drive_run(
+        "+vim#My Editor",
+        menu_side_effect=["+vim#My Editor", remove_option, ""],
+    )
+
+    confirm_prompt = menu_mock.call_args_list[1][0][0]
+    assert "Alias 'My Editor' already in store" in confirm_prompt
+
+
+# ---------------------------------------------------------------------------
+# The - -> + flip ("not found in store") prompt
+# ---------------------------------------------------------------------------
+
+
+def test_remove_absent_plain_item_prompts_to_add_then_flips_to_addition(store):
+    # "-firefox" while firefox is NOT in include_items: found_in_store is False,
+    # so a confirmation offers "-> Add to store". Accepting flips action to "+"
+    # and the item is added.
+    store.write_cache(["other"])
+    store.write_aliases([])
+    main.d.prefs["include_items"] = []
+
+    add_option = main.d.prefs["indicator_submenu"] + " Add to store"
+    menu_mock = drive_run("-firefox", menu_side_effect=["-firefox", add_option, ""])
+
+    assert "firefox" in main.d.prefs["include_items"]
+    confirm_prompt = menu_mock.call_args_list[1][0][0]
+    assert "was not found in store" in confirm_prompt
+    assert menu_mock.call_args_list[-1][0][0].startswith("New item")
+
+
+def test_remove_absent_plain_item_declined_exits_without_change(store):
+    # Declining the "Add to store" offer exits immediately, adding nothing.
+    store.write_cache(["other"])
+    store.write_aliases([])
+    main.d.prefs["include_items"] = []
+
+    drive_run("-firefox", menu_side_effect=["-firefox", "nope"])
+
+    assert main.d.prefs["include_items"] == []
+
+
+# ---------------------------------------------------------------------------
+# found_in_store matching loop specifics
+# ---------------------------------------------------------------------------
+
+
+def test_found_in_store_plain_string_item_match(store):
+    # A plain string include_item that equals the command is detected by the
+    # final `isinstance(item, list)` ... wait: the last branch checks
+    # `command == item` only when `isinstance(item, list)`. A plain string item
+    # therefore does NOT satisfy that branch, so "+firefox" with a *string*
+    # include_item "firefox" is treated as NOT found and is appended again
+    # (duplicated). This pins that quirk.
+    store.write_cache(["firefox"])
+    store.write_aliases([])
+    main.d.prefs["include_items"] = ["firefox"]
+
+    drive_run("+firefox")
+
+    # firefox ends up listed twice because the string item was not matched.
+    assert main.d.prefs["include_items"].count("firefox") == 2
+
+
+def test_found_in_store_alias_pair_matched_on_add_by_alias(store):
+    # For an add ("+"), the loop matches an existing [alias, command] pair when
+    # alias == item[0]. So "+vim#My Editor" with the pair already present is
+    # found_in_store True and triggers the remove confirmation rather than a
+    # second append.
+    store.write_cache(["My Editor"])
+    store.write_aliases([["My Editor", "vim"]])
+    main.d.prefs["include_items"] = [["My Editor", "vim"]]
+
+    # Decline the resulting "Remove from store" confirmation so nothing changes.
+    drive_run("+vim#My Editor", menu_side_effect=["+vim#My Editor", "declined"])
+
+    # The pair was detected as present; declining left it untouched (not added
+    # again).
+    assert main.d.prefs["include_items"].count(["My Editor", "vim"]) == 1
+
+
+# ---------------------------------------------------------------------------
+# Quirk: missing cache file raises TypeError (dead False-branch)
+# ---------------------------------------------------------------------------
+
+
+def test_missing_cache_file_raises_typeerror(store):
+    # cache_open() returns False for a missing file; the block immediately
+    # slices it with `[:-1]`, and `False[:-1]` raises TypeError. The intended
+    # `cache_scanned is False` recovery branch is therefore unreachable.
+    store.write_aliases([])
+    main.d.prefs["include_items"] = []
+    # Deliberately do NOT create the cache file.
+    assert not os.path.exists(store.cache)
+
+    menu_mock = mock.Mock(side_effect=["+firefox", ""])
+    stack, _ = patches(
+        mock.patch.object(main, "init_menu", return_value=None),
+        mock.patch.object(main.d, "cache_load", return_value="ignored"),
+        mock.patch.object(main.d, "menu", menu_mock),
+        mock.patch.object(main, "load_plugins", return_value=[]),
+        mock.patch.object(main.d, "retrieve_aliased_command", return_value=None),
+        mock.patch.object(main.d, "message_open"),
+        mock.patch.object(main.d, "message_close"),
+        mock.patch.object(main, "frequent_commands_store"),
+    )
+    with stack:
+        with pytest.raises(TypeError):
+            main.run()
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([__file__, "-q"]))

--- a/tests/test_settings_menu.py
+++ b/tests/test_settings_menu.py
@@ -1,0 +1,451 @@
+#!/usr/bin/env python3
+
+"""Characterisation tests for the Settings submenu (extension class).
+
+These pin down the CURRENT actual behaviour of three pieces of the settings
+plugin in dmenu_extended.main:
+
+  * extension.run() - how it assembles the action list (which items appear
+    depending on installed plugins, frequently_used and the systemd status)
+    and how it dispatches options.index(item) -> actions[index]().
+  * extension.get_automatic_rebuild_cache_status() - its 0/1/2 return values
+    over the which/systemctl/list-unit-files/is-enabled subprocess boundaries.
+  * extension.rebuild_cache() - the cache-size-delta wording it feeds to menu().
+
+Every boundary that would touch the real system is mocked: subprocess.call /
+subprocess.check_output, and the UI methods select() / menu(). The real
+dispatch and branching bodies are allowed to run.
+"""
+
+import sys
+from os import path
+
+import mock
+import pytest
+
+# Add src directory to path to import dmenu_extended
+sys.path.insert(0, path.join(path.dirname(__file__), "..", "src"))
+from dmenu_extended import main
+
+
+def make_extension(prefs=None):
+    """Build an extension instance without running __init__.
+
+    extension.__init__ calls load_preferences which would read the real user
+    config from disk, so we bypass it via __new__ and inject prefs directly.
+    """
+    inst = main.extension.__new__(main.extension)
+    if prefs is None:
+        prefs = {"indicator_submenu": "->", "frequently_used": 0}
+    inst.prefs = prefs
+    return inst
+
+
+# ---------------------------------------------------------------------------
+# extension.run() - action-list assembly
+# ---------------------------------------------------------------------------
+
+
+def _run_and_capture_items(inst, plugins, status, selected=-1):
+    """Drive run() with the boundaries stubbed and return the items offered.
+
+    installed_plugins(), get_automatic_rebuild_cache_status() and select() are
+    all patched. select() returns -1 by default so dispatch is skipped (run()
+    only dispatches when the result is not -1). Returns the list passed to
+    select().
+    """
+    with (
+        mock.patch.object(inst, "installed_plugins", return_value=plugins),
+        mock.patch.object(
+            inst, "get_automatic_rebuild_cache_status", return_value=status
+        ),
+        mock.patch.object(inst, "select", return_value=selected) as select,
+    ):
+        inst.run("")
+    return select.call_args[0][0]
+
+
+def test_run_base_items_when_no_plugins_no_recent_no_systemd():
+    # No installed plugins, frequently_used == 0, systemd status 0: only the two
+    # always-present items plus "Edit menu preferences" are offered.
+    inst = make_extension({"indicator_submenu": "->", "frequently_used": 0})
+    items = _run_and_capture_items(inst, plugins=[], status=0)
+    assert items == [
+        "Rebuild cache",
+        "-> Download new plugins",
+        "Edit menu preferences",
+    ]
+
+
+def test_run_plugin_items_appear_only_when_plugins_installed():
+    # With at least one installed plugin, the remove + update plugin items appear
+    # immediately after the download item.
+    inst = make_extension({"indicator_submenu": "->", "frequently_used": 0})
+    items = _run_and_capture_items(inst, plugins=["foo (plugin_foo.py)"], status=0)
+    assert items == [
+        "Rebuild cache",
+        "-> Download new plugins",
+        "-> Remove existing plugins",
+        "Update installed plugins",
+        "Edit menu preferences",
+    ]
+
+
+def test_run_clear_recent_item_appears_only_when_frequently_used_positive():
+    # frequently_used > 0 adds the "Clear recent entries" item after the edit
+    # preferences item.
+    inst = make_extension({"indicator_submenu": "->", "frequently_used": 5})
+    items = _run_and_capture_items(inst, plugins=[], status=0)
+    assert items == [
+        "Rebuild cache",
+        "-> Download new plugins",
+        "Edit menu preferences",
+        "Clear recent entries",
+    ]
+
+
+def test_run_systemd_status_one_offers_disable_item():
+    # Status 1 (timer installed and enabled) offers the "Disable" item only.
+    inst = make_extension({"indicator_submenu": "->", "frequently_used": 0})
+    items = _run_and_capture_items(inst, plugins=[], status=1)
+    assert items[-1] == "Disable automatic cache rebuilding"
+    assert "Enable automatic cache rebuilding" not in items
+
+
+def test_run_systemd_status_two_offers_enable_item():
+    # Status 2 (timer installed but disabled) offers the "Enable" item only.
+    inst = make_extension({"indicator_submenu": "->", "frequently_used": 0})
+    items = _run_and_capture_items(inst, plugins=[], status=2)
+    assert items[-1] == "Enable automatic cache rebuilding"
+    assert "Disable automatic cache rebuilding" not in items
+
+
+def test_run_systemd_status_zero_omits_both_systemd_items():
+    inst = make_extension({"indicator_submenu": "->", "frequently_used": 0})
+    items = _run_and_capture_items(inst, plugins=[], status=0)
+    assert "Disable automatic cache rebuilding" not in items
+    assert "Enable automatic cache rebuilding" not in items
+
+
+def test_run_all_items_present_with_plugins_recent_and_enabled_timer():
+    # Every conditional branch active at once: plugins installed, recent enabled,
+    # systemd timer enabled (status 1 -> Disable item).
+    inst = make_extension({"indicator_submenu": "->", "frequently_used": 3})
+    items = _run_and_capture_items(inst, plugins=["foo (plugin_foo.py)"], status=1)
+    assert items == [
+        "Rebuild cache",
+        "-> Download new plugins",
+        "-> Remove existing plugins",
+        "Update installed plugins",
+        "Edit menu preferences",
+        "Clear recent entries",
+        "Disable automatic cache rebuilding",
+    ]
+
+
+# ---------------------------------------------------------------------------
+# extension.run() - dispatch via options.index(item) -> actions[index]()
+# ---------------------------------------------------------------------------
+
+
+def _dispatch(inst, selected, plugins=None, status=0, frequently_used=0):
+    """Run dispatch for ``selected`` and return the patched action mocks.
+
+    Returns a dict mapping action-method name -> mock so the test can assert
+    exactly one of them fired. The eight action methods are patched out so the
+    dispatch table can be exercised without running the real bodies.
+    """
+    inst.prefs = {"indicator_submenu": "->", "frequently_used": frequently_used}
+    action_names = [
+        "rebuild_cache",
+        "download_plugins",
+        "remove_plugin",
+        "update_plugins",
+        "edit_preferences",
+        "clear_recent",
+        "disable_automatic_rebuild_cache",
+        "enable_automatic_rebuild_cache",
+    ]
+    patchers = {name: mock.patch.object(inst, name) for name in action_names}
+    mocks = {name: p.start() for name, p in patchers.items()}
+    try:
+        with (
+            mock.patch.object(inst, "installed_plugins", return_value=plugins or []),
+            mock.patch.object(
+                inst, "get_automatic_rebuild_cache_status", return_value=status
+            ),
+            mock.patch.object(inst, "select", return_value=selected),
+        ):
+            inst.run("")
+    finally:
+        for p in patchers.values():
+            p.stop()
+    return mocks
+
+
+def test_dispatch_rebuild_cache():
+    inst = make_extension()
+    mocks = _dispatch(inst, selected="Rebuild cache")
+    mocks["rebuild_cache"].assert_called_once_with()
+    # No other action fired.
+    assert sum(m.called for m in mocks.values()) == 1
+
+
+def test_dispatch_download_plugins():
+    inst = make_extension()
+    mocks = _dispatch(inst, selected="-> Download new plugins")
+    mocks["download_plugins"].assert_called_once_with()
+    assert sum(m.called for m in mocks.values()) == 1
+
+
+def test_dispatch_remove_plugin():
+    inst = make_extension()
+    mocks = _dispatch(
+        inst, selected="-> Remove existing plugins", plugins=["foo (plugin_foo.py)"]
+    )
+    mocks["remove_plugin"].assert_called_once_with()
+    assert sum(m.called for m in mocks.values()) == 1
+
+
+def test_dispatch_update_plugins():
+    inst = make_extension()
+    mocks = _dispatch(
+        inst, selected="Update installed plugins", plugins=["foo (plugin_foo.py)"]
+    )
+    mocks["update_plugins"].assert_called_once_with()
+    assert sum(m.called for m in mocks.values()) == 1
+
+
+def test_dispatch_edit_preferences():
+    inst = make_extension()
+    mocks = _dispatch(inst, selected="Edit menu preferences")
+    mocks["edit_preferences"].assert_called_once_with()
+    assert sum(m.called for m in mocks.values()) == 1
+
+
+def test_dispatch_clear_recent():
+    inst = make_extension()
+    mocks = _dispatch(inst, selected="Clear recent entries", frequently_used=4)
+    mocks["clear_recent"].assert_called_once_with()
+    assert sum(m.called for m in mocks.values()) == 1
+
+
+def test_dispatch_disable_automatic_rebuild():
+    inst = make_extension()
+    mocks = _dispatch(inst, selected="Disable automatic cache rebuilding", status=1)
+    mocks["disable_automatic_rebuild_cache"].assert_called_once_with()
+    assert sum(m.called for m in mocks.values()) == 1
+
+
+def test_dispatch_enable_automatic_rebuild():
+    inst = make_extension()
+    mocks = _dispatch(inst, selected="Enable automatic cache rebuilding", status=2)
+    mocks["enable_automatic_rebuild_cache"].assert_called_once_with()
+    assert sum(m.called for m in mocks.values()) == 1
+
+
+def test_dispatch_does_nothing_when_select_returns_minus_one():
+    # select() returns -1 when nothing matched; run() then skips dispatch and no
+    # action method is invoked.
+    inst = make_extension()
+    mocks = _dispatch(inst, selected=-1)
+    assert all(not m.called for m in mocks.values())
+
+
+# ---------------------------------------------------------------------------
+# get_automatic_rebuild_cache_status() - 0/1/2 over the subprocess boundaries
+# ---------------------------------------------------------------------------
+
+
+def test_status_zero_when_systemctl_absent():
+    # `which systemctl` returning non-zero means no systemd: status 0, and no
+    # further systemctl calls are attempted.
+    inst = make_extension()
+    with (
+        mock.patch("subprocess.call", return_value=1) as call,
+        mock.patch("subprocess.check_output") as check,
+    ):
+        assert inst.get_automatic_rebuild_cache_status() == 0
+    # Only the `which systemctl` probe ran; daemon-reload / is-enabled never did.
+    call.assert_called_once_with(["which", "systemctl"])
+    assert check.called is False
+
+
+def test_status_zero_when_list_unit_files_raises():
+    # If list-unit-files raises CalledProcessError, status is 0.
+    inst = make_extension()
+    with (
+        mock.patch("subprocess.call", return_value=0),
+        mock.patch(
+            "subprocess.check_output",
+            side_effect=main.subprocess.CalledProcessError(1, "systemctl"),
+        ),
+    ):
+        assert inst.get_automatic_rebuild_cache_status() == 0
+
+
+def test_status_zero_when_timer_not_listed():
+    # `which` and daemon-reload succeed but the timer unit is not in the
+    # list-unit-files output, so status is 0.
+    inst = make_extension()
+    with (
+        mock.patch("subprocess.call", return_value=0),
+        mock.patch("subprocess.check_output", return_value=b"some-other.timer\n"),
+    ):
+        assert inst.get_automatic_rebuild_cache_status() == 0
+
+
+def test_status_one_when_timer_enabled():
+    # Timer present and `is-enabled` returns 0 -> status 1 (running/enabled).
+    inst = make_extension()
+    call_values = iter([0, 0, 0])  # which, daemon-reload, is-enabled
+
+    def fake_call(cmd):
+        return next(call_values)
+
+    with (
+        mock.patch("subprocess.call", side_effect=fake_call),
+        mock.patch(
+            "subprocess.check_output",
+            return_value=b"dmenu-extended-update-db.timer enabled\n",
+        ),
+    ):
+        assert inst.get_automatic_rebuild_cache_status() == 1
+
+
+def test_status_two_when_timer_disabled():
+    # Timer present but `is-enabled` returns non-zero -> status 2 (not running).
+    inst = make_extension()
+    call_values = iter([0, 0, 1])  # which, daemon-reload, is-enabled
+
+    def fake_call(cmd):
+        return next(call_values)
+
+    with (
+        mock.patch("subprocess.call", side_effect=fake_call),
+        mock.patch(
+            "subprocess.check_output",
+            return_value=b"dmenu-extended-update-db.timer disabled\n",
+        ),
+    ):
+        assert inst.get_automatic_rebuild_cache_status() == 2
+
+
+def test_status_issues_is_enabled_probe_for_the_timer_unit():
+    # Confirm the is-enabled probe targets the correct timer unit name.
+    inst = make_extension()
+    calls = []
+
+    def fake_call(cmd):
+        calls.append(cmd)
+        return 0
+
+    with (
+        mock.patch("subprocess.call", side_effect=fake_call),
+        mock.patch(
+            "subprocess.check_output",
+            return_value=b"dmenu-extended-update-db.timer enabled\n",
+        ),
+    ):
+        inst.get_automatic_rebuild_cache_status()
+    assert calls[-1] == [
+        "systemctl",
+        "--user",
+        "is-enabled",
+        "dmenu-extended-update-db.timer",
+    ]
+
+
+# ---------------------------------------------------------------------------
+# rebuild_cache() - cache-size-delta messaging
+# ---------------------------------------------------------------------------
+
+
+def _rebuild_with_sizes(inst, before_lines, after_lines, regenerate_result=True):
+    """Run rebuild_cache() with cache_load returning two distinct sizes.
+
+    cache_load() is called twice (before and after regenerate); we feed it a
+    string with the requested number of newline-joined lines each time. The menu
+    response list is captured and returned.
+    """
+    before = "\n".join(["x"] * before_lines)
+    after = "\n".join(["x"] * after_lines)
+    with (
+        mock.patch.object(inst, "cache_load", side_effect=[before, after]),
+        mock.patch.object(inst, "cache_regenerate", return_value=regenerate_result),
+        mock.patch.object(inst, "menu") as menu,
+    ):
+        inst.rebuild_cache()
+    return menu.call_args[0][0]
+
+
+def test_rebuild_cache_singular_added():
+    # A net change of +1 item uses the singular "one new item was added." wording.
+    inst = make_extension()
+    response = _rebuild_with_sizes(inst, before_lines=2, after_lines=3)
+    assert response[0] == "Cache updated successfully; one new item was added."
+
+
+def test_rebuild_cache_plural_added():
+    # A net change of +3 uses the plural "<n> items were added." wording.
+    inst = make_extension()
+    response = _rebuild_with_sizes(inst, before_lines=2, after_lines=5)
+    assert response[0] == "Cache updated successfully; 3 items were added."
+
+
+def test_rebuild_cache_singular_removed():
+    # A net change of -1 uses the singular "one item was removed." wording.
+    inst = make_extension()
+    response = _rebuild_with_sizes(inst, before_lines=5, after_lines=4)
+    assert response[0] == "Cache updated successfully; one item was removed."
+
+
+def test_rebuild_cache_plural_removed():
+    # A net change of -3 uses "<abs(n)> items were removed.".
+    inst = make_extension()
+    response = _rebuild_with_sizes(inst, before_lines=6, after_lines=3)
+    assert response[0] == "Cache updated successfully; 3 items were removed."
+
+
+def test_rebuild_cache_size_did_not_change():
+    # Equal before/after sizes produce the single "size did not change" line.
+    inst = make_extension()
+    response = _rebuild_with_sizes(inst, before_lines=4, after_lines=4)
+    assert response[0] == "Cache rebuilt; its size did not change."
+    # No performance notice is appended on the unchanged path.
+    assert len(response) == 2
+
+
+def test_rebuild_cache_performance_notice_when_result_is_two():
+    # When cache_regenerate returns 2 (performance issues) AND the size changed,
+    # a NOTICE line is inserted between the status line and the summary line.
+    inst = make_extension()
+    response = _rebuild_with_sizes(
+        inst, before_lines=2, after_lines=4, regenerate_result=2
+    )
+    assert response[0] == "Cache updated successfully; 2 items were added."
+    assert response[1] == (
+        "NOTICE: Performance issues were encountered while caching data"
+    )
+
+
+def test_rebuild_cache_no_performance_notice_when_size_unchanged():
+    # The performance NOTICE only fires on the "size changed" branch; an
+    # unchanged size with result==2 still omits it.
+    inst = make_extension()
+    response = _rebuild_with_sizes(
+        inst, before_lines=4, after_lines=4, regenerate_result=2
+    )
+    assert all("NOTICE" not in line for line in response)
+
+
+def test_rebuild_cache_summary_reports_original_size():
+    # The final summary line reports the ORIGINAL (pre-rebuild) cache size, not
+    # the new one - a quirk worth pinning.
+    inst = make_extension()
+    response = _rebuild_with_sizes(inst, before_lines=7, after_lines=10)
+    assert response[-1].startswith("The cache contains 7 items and took ")
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([__file__, "-q"]))


### PR DESCRIPTION
Phase 0 of the plugin-system hardening: a characterisation test net that pins the **current** behaviour of dmenu-extended so the upcoming refactor cannot regress it silently. Behaviour is asserted as-is (quirks included), mocking only at the subprocess / network / filesystem boundaries - no real dmenu, no network, no real `~/.config`.

## Coverage (249 new tests, 261 total)
- **Preferences** - load/save/migrate, defaults, path resolution
- **Cache** - build/load/save, scan binaries + applications, alias parsing, include/exclude shaping
- **Menu I/O** - `menu()`, `select()`, `message_open/close` (mocked dmenu `Popen`, argv + prompt + expandvars)
- **Execute** - `execute()` (both interactive-shell branches), `command_to_list`, terminal launch, open-with / url / terminal-editor, and the `: @ ; ;; + -` modifier characters
- **run() dispatch** - the colon "open X with Y" block and the `+/-` store-modification block (the two highest-risk, side-effect-heavy paths)
- **Settings menu** - `extension.run()` action assembly + dispatch, systemd status probe, rebuild-cache messaging
- **Plugins** - discovery/load, `download_plugins` / `update_plugins`, requirement/version logic
- **Entry points** - `init_menu()` / `run()` launch-arg handling, executable check

Authored and adversarially reviewed by independent agents (each verified the tests exercise real function bodies, not mock tautologies - confirmed by mutation-checking that breaking the source fails the tests).

## Also
- `requires-python` `>=3.8` -> `>=3.9`: the repo's standard ruff formatter emits parenthesised multi-context `with` statements (a 3.9+ construct), so a 3.8 floor is inconsistent with the toolchain. 3.8 is end-of-life and CI only exercises 3.11+.

Phase 1 (plugins-repo `sha256` + generator) and Phase 2 (client read/verify + `plugin_repositories`) build on this net.