### PR TITLE
feat: verified, configurable plugin sources

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,7 @@ Functions of the items are as follows.
 - `"include_applications"` add items found under /usr/share/applications
 - `"alias_applications"` alias applications with their intended names
 - `"path_aliasFile"` path to a file containing aliases (e.g. ~/.bash_aliases)
+- `"plugin_repositories"` list of plugin sources (base URLs or local paths) to install plugins from; the official repository is included by default
 - `"abbreviate_homedir"` abbreviate $HOME as `~` for files & folders
 - `"frequently_used"` the number of your most frequently used commands to show at the top of the menu
 - `"alias_display_format"` how to format aliased commands (e.g. `"{name} ({command})"`)

--- a/src/dmenu_extended/main.py
+++ b/src/dmenu_extended/main.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 
+import hashlib
 import importlib
 import importlib.metadata
 import json
@@ -113,6 +114,9 @@ path_cache = os.getenv("DMENU_EXTENDED_CACHE_DIR") or (
 path_prefs = path_base + "/config"
 path_plugins = path_base + "/plugins"
 
+# Seconds to wait when downloading a plugin index or plugin file.
+plugin_download_timeout = 15
+
 file_prefs = path_prefs + "/dmenuExtended_preferences.txt"
 file_cache = path_cache + "/dmenuExtended_all.txt"
 file_cache_binaries = path_cache + "/dmenuExtended_binaries.txt"
@@ -178,6 +182,11 @@ default_prefs = {
     "alias_applications": True,  # Alias applications with their common names
     "path_aliasFile": "",  # Pointer to an aliases file (if any)
     "abbreviate_homedir": False,  # Use ~ in place of /home/username
+    "plugin_repositories": [
+        # Base URLs (or local directory paths) that contain a plugins_index.json.
+        # Add your own; downloads are verified against the index sha256 hash.
+        "https://raw.githubusercontent.com/markhedleyjones/dmenu-extended-plugins/main",
+    ],
     "frequently_used": 0,  # Number of most frequently used commands to show in the menu
     "alias_display_format": "{name}",
     "path_shellCommand": "~/.dmenuEextended_shellCommand.sh",
@@ -509,10 +518,42 @@ class dmenu(object):
         self.save_json(file_prefs, self.prefs)
 
     def download_text(self, url):
-        return urllib.request.urlopen(url).read()
+        return urllib.request.urlopen(url, timeout=plugin_download_timeout).read()
 
     def download_json(self, url):
         return json.loads(self.download_text(url))
+
+    def fetch_resource(self, location):
+        """Return the bytes of a plugin resource from an https URL or local path.
+
+        Plain http is refused - an installed plugin is executed, so its source
+        must not be interceptable in transit.
+        """
+        if location.startswith(("http://", "https://")):
+            if not location.startswith("https://"):
+                raise ValueError(
+                    "refusing to fetch plugin over plain http: " + location
+                )
+            return urllib.request.urlopen(
+                location, timeout=plugin_download_timeout
+            ).read()
+        with open(os.path.expanduser(location), "rb") as handle:
+            return handle.read()
+
+    @staticmethod
+    def verify_plugin(meta, data):
+        """Check downloaded plugin bytes against the index hash (sha256 preferred).
+
+        Returns True only on a positive match; a missing hash is treated as a
+        failure so unverifiable plugins are never installed.
+        """
+        if meta.get("sha256"):
+            return hashlib.sha256(data).hexdigest() == meta["sha256"]
+        if meta.get("sha1sum"):
+            print("warning: plugin provides only a sha1 hash; sha256 is preferred")
+            return hashlib.sha1(data).hexdigest() == meta["sha1sum"]
+        print("warning: plugin index entry has no integrity hash; refusing")
+        return False
 
     def message_open(self, message):
         self.load_preferences()
@@ -1373,12 +1414,13 @@ class extension(dmenu):
     def __init__(self):
         self.load_preferences()
 
-    base_url = "https://raw.githubusercontent.com"
-    plugins_index_urls = [
-        f"{base_url}/markhedleyjones/dmenu-extended-plugins/master/plugins_index.json",
-        f"{base_url}/v1nc/dmenu-extended-plugins/master/plugins_index.json",
-        f"{base_url}/mg979/dmenu-extended-plugins/master/plugins_index.json",
-    ]
+    def repository_bases(self):
+        """Trusted plugin repository bases from the plugin_repositories preference.
+
+        Each is a base URL (or local directory) that holds a plugins_index.json
+        and the plugin files. Configurable so users can add their own sources.
+        """
+        return [base.rstrip("/") for base in self.prefs.get("plugin_repositories", [])]
 
     def rebuild_cache(self):
         global debug
@@ -1439,19 +1481,23 @@ class extension(dmenu):
 
     def download_plugins_json(self):
         plugins = {}
-        for plugins_index_url in self.plugins_index_urls:
+        for base in self.repository_bases():
             try:
-                plugins.update(self.download_json(plugins_index_url))
+                index = json.loads(self.fetch_resource(base + "/plugins_index.json"))
             except Exception as e:
                 print("Error downloading plugins index: " + str(e))
                 self.message_close()
                 self.menu(
                     [
-                        "Error: Could not connect to plugin repository.",
-                        "Please check your internet connection and try again.",
+                        "Error: Could not read plugin repository " + base,
+                        "Please check your connection or configuration and try again.",
                     ]
                 )
                 sys.exit()
+            for name, meta in index.items():
+                entry = dict(meta)
+                entry["repository"] = base
+                plugins[name] = entry
         return plugins
 
     def download_plugins(self):
@@ -1546,7 +1592,16 @@ class extension(dmenu):
                             ]
                         )
                     else:
-                        plugin_source = self.download_text(plugin["url"])
+                        source = plugin["repository"] + "/" + plugin_name + ".py"
+                        plugin_source = self.fetch_resource(source)
+                        if not self.verify_plugin(plugin, plugin_source):
+                            self.message_close()
+                            self.menu(
+                                [
+                                    "Plugin failed its integrity check and was not installed"
+                                ]
+                            )
+                            return
                         with open(path_plugins + "/" + plugin_name + ".py", "wb") as f:
                             f.write(plugin_source)
 
@@ -1613,52 +1668,25 @@ class extension(dmenu):
         self.message_close()
         updated = []
         for here in plugins_here:
-            for there in plugins_there:
-                if there == here:
-                    there_sha = plugins_there[there]["sha1sum"]
-                    here_sha = self.command_output(
-                        "sha1sum " + path_plugins + "/" + here + ".py"
-                    )[0].split()[0]
+            meta = plugins_there.get(here)
+            if meta is None:
+                continue
+            local_path = path_plugins + "/" + here + ".py"
+            with open(local_path, "rb") as handle:
+                if self.verify_plugin(meta, handle.read()):
                     if debug:
-                        print("Checking " + here)
-                        print("Local copy has sha of " + here_sha)
-                        print("Remote copy has sha of " + there_sha)
-                    if there_sha != here_sha:
-                        sys.stdout.write("Hashes do not match, updating...\n")
-                        if os.path.exists("/tmp/" + there + ".py"):
-                            os.remove("/tmp/" + there + ".py")
-                        subprocess.call(
-                            ["wget", plugins_there[there]["url"], "-P", "/tmp"]
-                        )
-                        download_sha = self.command_output(
-                            "sha1sum /tmp/" + here + ".py"
-                        )[0].split()[0]
-                        if download_sha != there_sha:
-                            if debug:
-                                print(
-                                    "Downloaded version of "
-                                    + there
-                                    + " does not verify against package manager"
-                                    " sha1sum key"
-                                )
-                                print("SHA1SUM of downloaded version = " + download_sha)
-                                print(
-                                    "SHA1SUM specified by package manager = "
-                                    + there_sha
-                                )
-                                print("Plugin not updated")
-                        else:
-                            os.remove(path_plugins + "/" + here + ".py")
-                            shutil.move(
-                                "/tmp/" + here + ".py",
-                                path_plugins + "/" + here + ".py",
-                            )
-                            if debug:
-                                print("Done!")
-                            updated += [here]
-                    else:
-                        if debug:
-                            print(here + "is up-to-date")
+                        print(here + " is up-to-date")
+                    continue
+            if debug:
+                print("Hashes do not match, updating " + here)
+            new_source = self.fetch_resource(meta["repository"] + "/" + here + ".py")
+            if not self.verify_plugin(meta, new_source):
+                if debug:
+                    print("Downloaded " + here + " failed its integrity check")
+                continue
+            with open(local_path, "wb") as handle:
+                handle.write(new_source)
+            updated += [here]
         self.message_close()
         if len(updated) == 0:
             self.menu(["There are no new updates for installed plugins"])

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -9,11 +9,12 @@ example raising on a plugin index entry that lacks a requirements key), the
 test asserts the odd behaviour rather than the ideal one.
 
 All boundaries are mocked: no real dmenu/rofi is launched, no network request
-is made (download_text / download_json / urllib are stubbed), and any
-filesystem writes go to tmp_path or a tempfile directory.
+is made (fetch_resource / urllib are stubbed), and any filesystem writes go to
+tmp_path or a tempfile directory.
 """
 
 import contextlib
+import hashlib
 import os
 import sys
 import tempfile
@@ -325,34 +326,69 @@ def test_plugins_available_forces_plugin_reload():
 # ---------------------------------------------------------------------------
 
 
-def test_download_plugins_json_merges_all_index_urls():
-    # The index is fetched from every URL in plugins_index_urls and merged into
-    # a single dict (later URLs overwrite earlier keys via dict.update).
+def test_download_plugins_json_fetches_index_from_each_base():
+    # The index is fetched from "<base>/plugins_index.json" for every configured
+    # repository base, then merged into a single dict.
     inst = make_extension()
-    inst.plugins_index_urls = ["http://example/a.json", "http://example/b.json"]
-    with mock.patch.object(inst, "download_json") as dj:
-        dj.side_effect = [
-            {"plugin_a": {"url": "ua", "sha1sum": "sa"}},
-            {"plugin_b": {"url": "ub", "sha1sum": "sb"}},
+    inst.prefs = {"plugin_repositories": ["https://repo-a", "https://repo-b"]}
+    with mock.patch.object(inst, "fetch_resource") as fetch:
+        fetch.side_effect = [
+            b'{"plugin_a": {"url": "ua", "sha256": "sa"}}',
+            b'{"plugin_b": {"url": "ub", "sha256": "sb"}}',
         ]
         merged = inst.download_plugins_json()
 
-    assert dj.call_count == 2
+    # One fetch per base, addressed at the index file under each base.
+    assert [c[0][0] for c in fetch.call_args_list] == [
+        "https://repo-a/plugins_index.json",
+        "https://repo-b/plugins_index.json",
+    ]
     assert merged == {
-        "plugin_a": {"url": "ua", "sha1sum": "sa"},
-        "plugin_b": {"url": "ub", "sha1sum": "sb"},
+        "plugin_a": {"url": "ua", "sha256": "sa", "repository": "https://repo-a"},
+        "plugin_b": {"url": "ub", "sha256": "sb", "repository": "https://repo-b"},
     }
 
 
+def test_download_plugins_json_tags_entries_with_repository():
+    # Every merged entry is tagged with the base it came from so the install and
+    # update flows know where to fetch the plugin source.
+    inst = make_extension()
+    inst.prefs = {"plugin_repositories": ["https://repo-a"]}
+    with mock.patch.object(
+        inst,
+        "fetch_resource",
+        return_value=b'{"plugin_a": {"url": "ua", "sha256": "sa"}}',
+    ):
+        merged = inst.download_plugins_json()
+
+    assert merged["plugin_a"]["repository"] == "https://repo-a"
+
+
+def test_download_plugins_json_last_repository_wins_on_collision():
+    # When two repositories define the same plugin name, the later base in the
+    # list overwrites the earlier one (and so does its repository tag).
+    inst = make_extension()
+    inst.prefs = {"plugin_repositories": ["https://repo-a", "https://repo-b"]}
+    with mock.patch.object(inst, "fetch_resource") as fetch:
+        fetch.side_effect = [
+            b'{"plugin_x": {"url": "from-a", "sha256": "sa"}}',
+            b'{"plugin_x": {"url": "from-b", "sha256": "sb"}}',
+        ]
+        merged = inst.download_plugins_json()
+
+    assert merged["plugin_x"]["url"] == "from-b"
+    assert merged["plugin_x"]["repository"] == "https://repo-b"
+
+
 def test_download_plugins_json_error_exits():
-    # A failure fetching any index closes the wait message, shows an error menu,
-    # and exits the process via sys.exit().
+    # A failure reading any index closes the wait message, shows an error menu
+    # naming the offending base, and exits the process via sys.exit().
     import pytest
 
     inst = make_extension()
-    inst.plugins_index_urls = ["http://example/a.json"]
+    inst.prefs = {"plugin_repositories": ["https://repo-a"]}
     with (
-        mock.patch.object(inst, "download_json", side_effect=Exception("boom")),
+        mock.patch.object(inst, "fetch_resource", side_effect=Exception("boom")),
         mock.patch.object(inst, "message_close") as mc,
         mock.patch.object(inst, "menu") as menu,
     ):
@@ -361,8 +397,8 @@ def test_download_plugins_json_error_exits():
 
     assert mc.called
     assert menu.call_args[0][0] == [
-        "Error: Could not connect to plugin repository.",
-        "Please check your internet connection and try again.",
+        "Error: Could not read plugin repository https://repo-a",
+        "Please check your connection or configuration and try again.",
     ]
 
 
@@ -372,16 +408,17 @@ def test_download_plugins_json_error_exits():
 
 
 def test_download_plugins_installs_selected_plugin(tmp_path):
-    # The happy path: an index entry carrying url + sha1sum + desc + (empty)
-    # requirements is offered, selected, downloaded via download_text, and
-    # written to path_plugins as <plugin_name>.py.
+    # The happy path: an index entry carrying a sha256 + desc + (empty)
+    # requirements is offered, selected, fetched from "<repository>/<name>.py",
+    # verified, and written to path_plugins as <plugin_name>.py.
     inst = make_extension()
+    source = b"# plugin source"
     plugins_json = {
         "plugin_foo": {
-            "url": "http://example/foo.py",
-            "sha1sum": "abc123",
+            "sha256": hashlib.sha256(source).hexdigest(),
             "desc": "Foo plugin",
             "requirements": {},
+            "repository": "https://repo-a",
         }
     }
 
@@ -399,8 +436,8 @@ def test_download_plugins_installs_selected_plugin(tmp_path):
         )
         stack.enter_context(mock.patch.object(inst, "message_open"))
         stack.enter_context(mock.patch.object(inst, "message_close"))
-        dt = stack.enter_context(
-            mock.patch.object(inst, "download_text", return_value=b"# plugin source")
+        fetch = stack.enter_context(
+            mock.patch.object(inst, "fetch_resource", return_value=source)
         )
         stack.enter_context(mock.patch.object(inst, "plugins_available"))
         menu = stack.enter_context(mock.patch.object(inst, "menu"))
@@ -409,13 +446,58 @@ def test_download_plugins_installs_selected_plugin(tmp_path):
 
     # The selectable item has the "plugin_" prefix stripped for display.
     assert select.call_args[0][0] == ["foo - Foo plugin"]
-    # download_text is called with the plugin's url.
-    dt.assert_called_once_with("http://example/foo.py")
+    # The source is fetched from "<repository>/<plugin_name>.py".
+    fetch.assert_called_once_with("https://repo-a/plugin_foo.py")
     # The file is written back WITH the plugin_ prefix.
     written = tmp_path / "plugin_foo.py"
     assert written.exists()
-    assert written.read_bytes() == b"# plugin source"
+    assert written.read_bytes() == source
     assert menu.call_args[0][0] == ["Plugin downloaded and installed successfully"]
+
+
+def test_download_plugins_refuses_to_write_on_failed_verification(tmp_path):
+    # When the fetched source fails verify_plugin (sha256 mismatch), the install
+    # is aborted: the failure menu is shown and NO file is written to disk.
+    inst = make_extension()
+    plugins_json = {
+        "plugin_foo": {
+            "sha256": "0" * 64,  # does not match the fetched bytes
+            "desc": "Foo plugin",
+            "requirements": {},
+            "repository": "https://repo-a",
+        }
+    }
+
+    with contextlib.ExitStack() as stack:
+        stack.enter_context(
+            mock.patch.object(inst, "download_plugins_json", return_value=plugins_json)
+        )
+        stack.enter_context(
+            mock.patch.object(
+                inst, "get_plugins", return_value=[{"filename": "plugin_settings.py"}]
+            )
+        )
+        stack.enter_context(
+            mock.patch.object(inst, "select", return_value="foo - Foo plugin")
+        )
+        stack.enter_context(mock.patch.object(inst, "message_open"))
+        stack.enter_context(mock.patch.object(inst, "message_close"))
+        stack.enter_context(
+            mock.patch.object(inst, "fetch_resource", return_value=b"tampered source")
+        )
+        plugins_available = stack.enter_context(
+            mock.patch.object(inst, "plugins_available")
+        )
+        menu = stack.enter_context(mock.patch.object(inst, "menu"))
+        stack.enter_context(mock.patch.object(main, "path_plugins", str(tmp_path)))
+        inst.download_plugins()
+
+    assert menu.call_args[0][0] == [
+        "Plugin failed its integrity check and was not installed"
+    ]
+    # Nothing was written, and the success path (cache rebuild) was not reached.
+    assert list(tmp_path.iterdir()) == []
+    assert plugins_available.called is False
 
 
 def test_download_plugins_no_new_plugins(tmp_path):
@@ -604,18 +686,19 @@ def test_download_plugins_missing_external_dependency_aborts(tmp_path):
 
 
 def test_update_plugins_downloads_when_hash_differs(tmp_path):
-    # When the local sha1sum differs from the index sha1sum and the freshly
-    # downloaded copy verifies against the index, the old plugin is removed and
-    # the downloaded one is moved into place. wget downloads to /tmp.
+    # When the local file does not verify against the index hash, the new source
+    # is fetched from "<repository>/<name>.py"; once it verifies, the local file
+    # is overwritten in place (no /tmp, no wget, no subprocess).
     inst = make_extension()
-    plugins_there = {"foo": {"url": "http://example/foo.py", "sha1sum": "REMOTE_SHA"}}
-
-    def command_output(command, split=True):
-        # The downloaded copy lives at /tmp/foo.py and matches the remote sha.
-        if command == "sha1sum /tmp/foo.py":
-            return ["REMOTE_SHA  /tmp/foo.py"]
-        # The local copy reports a different sha.
-        return ["LOCAL_SHA  " + command]
+    new_source = b"# updated plugin source"
+    plugins_there = {
+        "foo": {
+            "sha256": hashlib.sha256(new_source).hexdigest(),
+            "repository": "https://repo-a",
+        }
+    }
+    local_file = tmp_path / "foo.py"
+    local_file.write_bytes(b"# stale local source")
 
     with contextlib.ExitStack() as stack:
         stack.enter_context(mock.patch.object(inst, "message_open"))
@@ -633,30 +716,72 @@ def test_update_plugins_downloads_when_hash_differs(tmp_path):
         stack.enter_context(
             mock.patch.object(inst, "download_plugins_json", return_value=plugins_there)
         )
-        stack.enter_context(
-            mock.patch.object(inst, "command_output", side_effect=command_output)
+        fetch = stack.enter_context(
+            mock.patch.object(inst, "fetch_resource", return_value=new_source)
         )
         menu = stack.enter_context(mock.patch.object(inst, "menu"))
-        call = stack.enter_context(mock.patch("subprocess.call"))
-        stack.enter_context(mock.patch("os.path.exists", return_value=False))
-        remove = stack.enter_context(mock.patch("os.remove"))
-        move = stack.enter_context(mock.patch("shutil.move"))
         stack.enter_context(mock.patch.object(main, "path_plugins", str(tmp_path)))
         inst.update_plugins()
 
-    # wget is invoked to download into /tmp.
-    assert call.call_args[0][0] == ["wget", "http://example/foo.py", "-P", "/tmp"]
-    # The stale local copy is removed and the verified download moved over it.
-    assert remove.call_args[0][0] == str(tmp_path) + "/foo.py"
-    assert move.call_args[0] == ("/tmp/foo.py", str(tmp_path) + "/foo.py")
+    # The new source is fetched from "<repository>/<name>.py".
+    fetch.assert_called_once_with("https://repo-a/foo.py")
+    # The verified download is written over the stale local copy.
+    assert local_file.read_bytes() == new_source
     assert menu.call_args[0][0] == ["foo was updated to the latest version"]
 
 
 def test_update_plugins_skips_when_hash_matches(tmp_path):
-    # When the local sha1sum already matches the index sha1sum, no download
-    # happens and the "no new updates" message is shown.
+    # When the local file already verifies against the index hash, nothing is
+    # fetched and the "no new updates" message is shown.
     inst = make_extension()
-    plugins_there = {"foo": {"url": "u", "sha1sum": "SAME"}}
+    source = b"# current plugin source"
+    plugins_there = {
+        "foo": {
+            "sha256": hashlib.sha256(source).hexdigest(),
+            "repository": "https://repo-a",
+        }
+    }
+    local_file = tmp_path / "foo.py"
+    local_file.write_bytes(source)
+
+    with contextlib.ExitStack() as stack:
+        stack.enter_context(mock.patch.object(inst, "message_open"))
+        stack.enter_context(mock.patch.object(inst, "message_close"))
+        stack.enter_context(
+            mock.patch.object(
+                inst,
+                "get_plugins",
+                return_value=[
+                    {"filename": "plugin_settings.py"},
+                    {"filename": "foo.py"},
+                ],
+            )
+        )
+        stack.enter_context(
+            mock.patch.object(inst, "download_plugins_json", return_value=plugins_there)
+        )
+        fetch = stack.enter_context(mock.patch.object(inst, "fetch_resource"))
+        menu = stack.enter_context(mock.patch.object(inst, "menu"))
+        stack.enter_context(mock.patch.object(main, "path_plugins", str(tmp_path)))
+        inst.update_plugins()
+
+    assert fetch.called is False
+    assert local_file.read_bytes() == source
+    assert menu.call_args[0][0] == ["There are no new updates for installed plugins"]
+
+
+def test_update_plugins_does_not_write_on_failed_verification(tmp_path):
+    # If the freshly fetched source fails verification, the local file is left
+    # untouched and the update is not counted.
+    inst = make_extension()
+    plugins_there = {
+        "foo": {
+            "sha256": "0" * 64,  # matches neither local nor fetched bytes
+            "repository": "https://repo-a",
+        }
+    }
+    local_file = tmp_path / "foo.py"
+    local_file.write_bytes(b"# stale local source")
 
     with contextlib.ExitStack() as stack:
         stack.enter_context(mock.patch.object(inst, "message_open"))
@@ -675,14 +800,13 @@ def test_update_plugins_skips_when_hash_matches(tmp_path):
             mock.patch.object(inst, "download_plugins_json", return_value=plugins_there)
         )
         stack.enter_context(
-            mock.patch.object(inst, "command_output", return_value=["SAME  irrelevant"])
+            mock.patch.object(inst, "fetch_resource", return_value=b"tampered source")
         )
         menu = stack.enter_context(mock.patch.object(inst, "menu"))
-        call = stack.enter_context(mock.patch("subprocess.call"))
         stack.enter_context(mock.patch.object(main, "path_plugins", str(tmp_path)))
         inst.update_plugins()
 
-    assert call.called is False
+    assert local_file.read_bytes() == b"# stale local source"
     assert menu.call_args[0][0] == ["There are no new updates for installed plugins"]
 
 
@@ -714,17 +838,120 @@ def test_update_plugins_requires_settings_plugin_present():
 # ---------------------------------------------------------------------------
 
 
-def test_plugins_index_urls_point_at_raw_github():
-    # The settings plugin pulls the index from raw.githubusercontent.com for the
-    # three known plugin repositories.
+def test_default_prefs_plugin_repositories_points_at_official_main_branch():
+    # The shipped default repository is the official plugins repo on its main
+    # branch, served over https.
+    repos = main.default_prefs["plugin_repositories"]
+    assert repos == [
+        "https://raw.githubusercontent.com/markhedleyjones/dmenu-extended-plugins/main"
+    ]
+
+
+# ---------------------------------------------------------------------------
+# repository_bases
+# ---------------------------------------------------------------------------
+
+
+def test_repository_bases_derived_from_prefs():
+    # repository_bases reads the plugin_repositories preference verbatim.
     inst = make_extension()
-    assert inst.base_url == "https://raw.githubusercontent.com"
-    assert len(inst.plugins_index_urls) == 3
-    assert all(
-        url.startswith("https://raw.githubusercontent.com")
-        and url.endswith("/plugins_index.json")
-        for url in inst.plugins_index_urls
-    )
+    inst.prefs = {"plugin_repositories": ["https://repo-a", "https://repo-b"]}
+    assert inst.repository_bases() == ["https://repo-a", "https://repo-b"]
+
+
+def test_repository_bases_strips_trailing_slash():
+    # A trailing slash on a configured base is stripped so "<base>/file" joins
+    # cleanly without a doubled slash.
+    inst = make_extension()
+    inst.prefs = {"plugin_repositories": ["https://repo-a/", "/local/path/"]}
+    assert inst.repository_bases() == ["https://repo-a", "/local/path"]
+
+
+def test_repository_bases_empty_when_pref_absent():
+    # With no plugin_repositories key the list is empty (the get() default).
+    inst = make_extension()
+    inst.prefs = {}
+    assert inst.repository_bases() == []
+
+
+# ---------------------------------------------------------------------------
+# verify_plugin
+# ---------------------------------------------------------------------------
+
+
+def test_verify_plugin_sha256_match():
+    data = b"plugin bytes"
+    meta = {"sha256": hashlib.sha256(data).hexdigest()}
+    assert main.extension.verify_plugin(meta, data) is True
+
+
+def test_verify_plugin_sha256_mismatch():
+    meta = {"sha256": "0" * 64}
+    assert main.extension.verify_plugin(meta, b"plugin bytes") is False
+
+
+def test_verify_plugin_sha256_takes_precedence_over_sha1(capsys):
+    # When a sha256 is present it is used and the sha1 branch (which prints a
+    # warning) is never reached.
+    data = b"plugin bytes"
+    meta = {
+        "sha256": hashlib.sha256(data).hexdigest(),
+        "sha1sum": "deadbeef",  # wrong, but should be ignored
+    }
+    assert main.extension.verify_plugin(meta, data) is True
+    assert "sha1" not in capsys.readouterr().out
+
+
+def test_verify_plugin_sha1_only_match(capsys):
+    # With no sha256, a matching sha1sum verifies, but a warning is printed.
+    data = b"plugin bytes"
+    meta = {"sha1sum": hashlib.sha1(data).hexdigest()}
+    assert main.extension.verify_plugin(meta, data) is True
+    assert "sha1" in capsys.readouterr().out
+
+
+def test_verify_plugin_sha1_only_mismatch():
+    meta = {"sha1sum": "0" * 40}
+    assert main.extension.verify_plugin(meta, b"plugin bytes") is False
+
+
+def test_verify_plugin_no_hash_returns_false(capsys):
+    # An entry with no integrity hash cannot be verified and is refused, with a
+    # warning printed.
+    assert main.extension.verify_plugin({}, b"plugin bytes") is False
+    assert "no integrity hash" in capsys.readouterr().out
+
+
+# ---------------------------------------------------------------------------
+# fetch_resource
+# ---------------------------------------------------------------------------
+
+
+def test_fetch_resource_refuses_plain_http():
+    import pytest
+
+    inst = make_extension()
+    with pytest.raises(ValueError):
+        inst.fetch_resource("http://example/plugin.py")
+
+
+def test_fetch_resource_reads_local_path(tmp_path):
+    inst = make_extension()
+    target = tmp_path / "plugin.py"
+    target.write_bytes(b"# local plugin source")
+    assert inst.fetch_resource(str(target)) == b"# local plugin source"
+
+
+def test_fetch_resource_https_uses_urllib():
+    # An https URL is fetched via urllib.request.urlopen and the bytes returned.
+    inst = make_extension()
+    response = mock.Mock()
+    response.read.return_value = b"# remote plugin source"
+    with mock.patch("urllib.request.urlopen", return_value=response) as urlopen:
+        out = inst.fetch_resource("https://example/plugin.py")
+
+    assert out == b"# remote plugin source"
+    assert urlopen.call_args[0][0] == "https://example/plugin.py"
 
 
 def test_module_path_cache_suffix():


### PR DESCRIPTION
Phase 2 (final) of the plugin-system hardening - the client side. Builds on the plugins-repo changes (sha256 now in the official index) and the characterisation safety net.

## What changes
- **`plugin_repositories` preference** - a list of base URLs (or local directory paths), defaulting to the official repository on the `main` branch. Users can add their own sources. This replaces the three **hard-coded** repositories that pointed at the deleted `master` branch (only one was official; the other two were third-party forks). Existing configs are migrated automatically (the default is backfilled on load).
- **Integrity verification before install** - a downloaded plugin is fetched from its own repository base and its hash checked against the index *before* the file is written or imported. Prefers `sha256`, falls back to `sha1sum` with a warning, and **refuses when no hash is present**. Previously the install path verified nothing.
- **https enforced + timeouts** - plain `http://` plugin sources are refused (an installed plugin is executed), and downloads time out.
- **Updater hardened** - `update_plugins` now verifies in memory with `hashlib` instead of shelling out to `wget` and `sha1sum` through `/tmp`.

## Closes the audit's remaining items
This addresses the plugin-trust gaps left open by the security release (no integrity check, baked-in third-party indexes, unconstrained URL scheme).

## Verification
- 277 tests pass, including with the menu binary absent (the CI condition).
- 51 plugin tests cover verification (sha256/sha1/no-hash), https enforcement, local paths, repository derivation, and that install/update refuse to write on a failed check.
- End-to-end: the client's `verify_plugin` accepts the live official index's `sha256` for every plugin downloaded fresh from `main`.

After this merges, dmenu-extended verifies every plugin it installs, and the plugin infrastructure across both repos is aligned and safer.