### PR TITLE
docs: add dmenu-extended AUR package to installation methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,9 @@ Alternatively, omit `sudo` from the above command to install dmenu-extended only
 
 ### Method 3: Install via AUR
 
-An AUR package is available here: [dmenu-extended-git](https://aur.archlinux.org/packages/dmenu-extended-git/).
+AUR packages are available here:
+- [dmenu-extended](https://aur.archlinux.org/packages/dmenu-extended/) — latest stable release
+- [dmenu-extended-git](https://aur.archlinux.org/packages/dmenu-extended-git/) — latest git version
 
 ## Usage
 


### PR DESCRIPTION
Hello again,

The README only listed [dmenu-extended-git](https://aur.archlinux.org/packages/dmenu-extended-git) for AUR installation. This adds the [dmenu-extended](https://aur.archlinux.org/packages/dmenu-extended) stable release package alongside it, giving Arch users a clear choice between the two options.


> The commit message in [the previous PR](https://github.com/markhedleyjones/dmenu-extended/pull/179) was linked to my old email address. That's why I opened another pr.